### PR TITLE
Refresh FURYOKU post-charter state anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,19 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 
 ## Current Anchors
 
-- Charter issue: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
-- Deferred execution tracker: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
+- Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
+- First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
+- Current bounded follow-on: [#11](https://github.com/JKhyro/FURYOKU/issues/11)
 
-## Active Evaluation Lane
+## Current Baseline
+
+- Local primary lane: `gemma3:4b-it-qat`
+- Regular benchmark-backed fallback candidate: `qwen2.5:7b`
+- Local-safe experimental slot: `gemma3-heretic:4b-q4km`
+- Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
+
+## Benchmark Evidence Lane
 
 - Local OpenClaw model benchmark: [`benchmarks/openclaw-local-llm`](benchmarks/openclaw-local-llm)
-
 - Latest benchmark result: [2026-03-24 summary](benchmarks/openclaw-local-llm/results/2026-03-24-summary.md)


### PR DESCRIPTION
## Summary
- replace the stale deferred-execution anchor with the completed first-wave closure issue
- add the current local/runtime baseline so repo truth matches the now-landed benchmark and routing decisions
- point the repo at the new bounded follow-on issue `#11`

## Why
Issue `#1` can now be ratified, but the repo surface still pointed at the old deferred-execution framing and did not show the post-`#10` baseline.

## Verification
- README links point to the active charter issue, the closed first-wave issue, discussion `#3`, and new follow-on issue `#11`
- baseline values match the benchmark and runtime reconciliation already landed through FURYOKU `#10`