### PR TITLE
Add compare truth publish helper

### DIFF
--- a/benchmarks/openclaw-local-llm/README.md
+++ b/benchmarks/openclaw-local-llm/README.md
@@ -45,13 +45,28 @@ Select a local model that fits a 32 GB RAM / 4 GB VRAM machine profile with the 
 2. Run `run_ollama_benchmark.ps1`.
 3. Run `run_ollama_response_suite.ps1` for same-prompt quality comparisons.
 4. Review the JSON output, including the attached `contractEvaluation`, `contractChecks`, `contractSummary`, `promotionVerdict`, `resourceFitVerdict`, and `compareDecision` fields.
-5. When you publish a compare lane, also emit `--current-baseline-output` so downstream runtime glue and automation can consume one compact baseline-selection manifest.
+5. When you publish a compare lane, run `publish_compare_truth.ps1` so the compare summary and current-baseline manifest are emitted together.
 6. Use alternate prompt files to probe specific lanes such as sexual-boundary behavior or harder capability tasks.
 
 Preset file:
 
 - `machine_profiles.json` contains reusable local hardware presets shared by the benchmark entrypoints and the Python contract reporter.
 - Use `-MachineProfileName <preset>` or `--machine-profile-name <preset>` to select a preset, and keep the direct `*MemoryMb` flags for one-off overrides.
+
+Publish current compare truth:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\publish_compare_truth.ps1
+```
+
+Publish an alternate compare set:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\publish_compare_truth.ps1 `
+  -InputPath .\benchmarks\openclaw-local-llm\results\candidate-compare-benchmark.json,.\benchmarks\openclaw-local-llm\results\candidate-compare-response-suite.json `
+  -SummaryOutputPath .\benchmarks\openclaw-local-llm\results\candidate-compare-summary.md `
+  -CurrentBaselineOutputPath .\benchmarks\openclaw-local-llm\results\candidate-current-baseline.json
+```
 
 Example:
 

--- a/benchmarks/openclaw-local-llm/publish_compare_truth.ps1
+++ b/benchmarks/openclaw-local-llm/publish_compare_truth.ps1
@@ -1,0 +1,107 @@
+[CmdletBinding()]
+param(
+    [string[]]$InputPath = @(),
+    [string]$SummaryOutputPath = "",
+    [string]$CurrentBaselineOutputPath = "",
+    [string]$Title = "Gemma 3 Heretic Q4_K_M vs Q5_K_M Contract Report (2026-04-09)",
+    [string]$MachineProfilePath = "",
+    [string]$MachineProfileName = "",
+    [string]$MachineProfileLabel = "",
+    [int]$ProfileSystemMemoryMb = 0,
+    [int]$ProfileGpuMemoryMb = 0,
+    [switch]$NoOverwrite
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$resultsDirectory = Join-Path $PSScriptRoot "results"
+
+if (-not $InputPath -or $InputPath.Count -eq 0) {
+    $InputPath = @(
+        (Join-Path $resultsDirectory "2026-04-09-gemma3-heretic-compare-benchmark.json"),
+        (Join-Path $resultsDirectory "2026-04-09-gemma3-heretic-compare-response-suite.json"),
+        (Join-Path $resultsDirectory "2026-04-09-gemma3-heretic-compare-sexual-boundary.json"),
+        (Join-Path $resultsDirectory "2026-04-09-gemma3-heretic-compare-advanced-suite.json")
+    )
+}
+
+if ([string]::IsNullOrWhiteSpace($SummaryOutputPath)) {
+    $SummaryOutputPath = Join-Path $resultsDirectory "2026-04-09-gemma3-heretic-compare-summary.md"
+}
+
+if ([string]::IsNullOrWhiteSpace($CurrentBaselineOutputPath)) {
+    $CurrentBaselineOutputPath = Join-Path $resultsDirectory "2026-04-09-gemma3-heretic-current-baseline.json"
+}
+
+if ([string]::IsNullOrWhiteSpace($MachineProfilePath)) {
+    $MachineProfilePath = Join-Path $PSScriptRoot "machine_profiles.json"
+}
+
+$contractReport = Join-Path $PSScriptRoot "benchmark_contract_report.py"
+if (-not (Test-Path $contractReport)) {
+    throw "benchmark_contract_report.py was not found at $contractReport."
+}
+
+$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCommand) {
+    throw "python is required to publish compare truth surfaces."
+}
+
+foreach ($path in $InputPath) {
+    if (-not (Test-Path $path)) {
+        throw "Compare input file was not found: $path"
+    }
+}
+
+$summaryDirectory = Split-Path -Parent $SummaryOutputPath
+if ($summaryDirectory -and -not (Test-Path $summaryDirectory)) {
+    New-Item -ItemType Directory -Path $summaryDirectory | Out-Null
+}
+
+$baselineDirectory = Split-Path -Parent $CurrentBaselineOutputPath
+if ($baselineDirectory -and -not (Test-Path $baselineDirectory)) {
+    New-Item -ItemType Directory -Path $baselineDirectory | Out-Null
+}
+
+$contractArgs = @($contractReport)
+foreach ($path in $InputPath) {
+    $contractArgs += @("--input", $path)
+}
+
+if (-not $NoOverwrite) {
+    $contractArgs += "--overwrite"
+}
+
+$contractArgs += @(
+    "--summary-output",
+    $SummaryOutputPath,
+    "--current-baseline-output",
+    $CurrentBaselineOutputPath,
+    "--title",
+    $Title
+)
+
+if (-not [string]::IsNullOrWhiteSpace($MachineProfilePath)) {
+    $contractArgs += @("--machine-profile-path", $MachineProfilePath)
+}
+if (-not [string]::IsNullOrWhiteSpace($MachineProfileName)) {
+    $contractArgs += @("--machine-profile-name", $MachineProfileName)
+}
+if (-not [string]::IsNullOrWhiteSpace($MachineProfileLabel)) {
+    $contractArgs += @("--machine-profile-label", $MachineProfileLabel)
+}
+if ($ProfileSystemMemoryMb -gt 0) {
+    $contractArgs += @("--profile-system-memory-mb", $ProfileSystemMemoryMb)
+}
+if ($ProfileGpuMemoryMb -gt 0) {
+    $contractArgs += @("--profile-gpu-memory-mb", $ProfileGpuMemoryMb)
+}
+
+& $pythonCommand.Source @contractArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Compare truth publish failed."
+}
+
+Write-Output "Published compare summary to $SummaryOutputPath"
+Write-Output "Published current-baseline manifest to $CurrentBaselineOutputPath"

--- a/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-advanced-suite.json
+++ b/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-advanced-suite.json
@@ -673,7 +673,7 @@
     }
   ],
   "contractEvaluation": {
-    "generatedAtUtc": "2026-04-09T21:41:21.866970+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.900064+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-advanced-suite.json",
     "passed": 18,
     "failed": 10,
@@ -695,7 +695,7 @@
     }
   },
   "promotionVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.866987+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.900076+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-advanced-suite.json",
     "models": {
       "gemma3-heretic:4b-q4km": {
@@ -777,7 +777,7 @@
     }
   },
   "compareDecision": {
-    "generatedAtUtc": "2026-04-09T21:41:21.867001+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.900087+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-advanced-suite.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",
@@ -897,7 +897,7 @@
     }
   },
   "resourceFitVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.866993+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.900081+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-advanced-suite.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",

--- a/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-benchmark.json
+++ b/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-benchmark.json
@@ -575,7 +575,7 @@
     }
   ],
   "contractEvaluation": {
-    "generatedAtUtc": "2026-04-09T21:41:21.848167+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.885613+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-benchmark.json",
     "passed": 15,
     "failed": 7,
@@ -597,7 +597,7 @@
     }
   },
   "promotionVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.848189+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.885627+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-benchmark.json",
     "models": {
       "gemma3-heretic:4b-q4km": {
@@ -662,7 +662,7 @@
     }
   },
   "compareDecision": {
-    "generatedAtUtc": "2026-04-09T21:41:21.848207+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.885637+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-benchmark.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",
@@ -772,7 +772,7 @@
     }
   },
   "resourceFitVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.848199+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.885632+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-benchmark.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",

--- a/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-response-suite.json
+++ b/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-response-suite.json
@@ -726,7 +726,7 @@
     }
   ],
   "contractEvaluation": {
-    "generatedAtUtc": "2026-04-09T21:41:21.856058+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.891094+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-response-suite.json",
     "passed": 12,
     "failed": 8,
@@ -748,7 +748,7 @@
     }
   },
   "promotionVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.856080+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.891114+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-response-suite.json",
     "models": {
       "gemma3-heretic:4b-q4km": {
@@ -820,7 +820,7 @@
     }
   },
   "compareDecision": {
-    "generatedAtUtc": "2026-04-09T21:41:21.856095+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.891129+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-response-suite.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",
@@ -940,7 +940,7 @@
     }
   },
   "resourceFitVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.856086+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.891121+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-response-suite.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",

--- a/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-sexual-boundary.json
+++ b/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-compare-sexual-boundary.json
@@ -683,7 +683,7 @@
     }
   ],
   "contractEvaluation": {
-    "generatedAtUtc": "2026-04-09T21:41:21.860908+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.895279+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-sexual-boundary.json",
     "passed": 10,
     "failed": 12,
@@ -705,7 +705,7 @@
     }
   },
   "promotionVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.860924+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.895292+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-sexual-boundary.json",
     "models": {
       "gemma3-heretic:4b-q4km": {
@@ -797,7 +797,7 @@
     }
   },
   "compareDecision": {
-    "generatedAtUtc": "2026-04-09T21:41:21.860943+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.895308+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-sexual-boundary.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",
@@ -937,7 +937,7 @@
     }
   },
   "resourceFitVerdict": {
-    "generatedAtUtc": "2026-04-09T21:41:21.860934+00:00",
+    "generatedAtUtc": "2026-04-10T03:23:29.895300+00:00",
     "source": "2026-04-09-gemma3-heretic-compare-sexual-boundary.json",
     "machineProfile": {
       "label": "32 GB RAM / 4 GB VRAM local profile",

--- a/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-current-baseline.json
+++ b/benchmarks/openclaw-local-llm/results/2026-04-09-gemma3-heretic-current-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAtUtc": "2026-04-09T21:41:21.869761+00:00",
+  "generatedAtUtc": "2026-04-10T03:23:29.902433+00:00",
   "title": "Gemma 3 Heretic Q4_K_M vs Q5_K_M Contract Report (2026-04-09)",
   "machineProfile": {
     "label": "32 GB RAM / 4 GB VRAM local profile",


### PR DESCRIPTION
Adds a one-command PowerShell helper for publishing FURYOKU compare truth surfaces. Verification: python -m py_compile benchmarks/openclaw-local-llm/benchmark_contract_report.py; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/publish_compare_truth.ps1; git diff --check. Closes #68.