### PR TITLE
Add model registry configuration loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ FURYOKU's primary job is to help the wider system choose the right LLM for the s
 Current routing core:
 
 - [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract.
+- [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
+- [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
 - [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, and three-role CHARACTER panel selection.
+- [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
 
 ## Benchmark Evidence Lane
 

--- a/examples/model_registry.example.json
+++ b/examples/model_registry.example.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "models": [
+    {
+      "modelId": "local-gemma3-heretic-q4",
+      "provider": "local",
+      "privacyLevel": "local",
+      "contextWindowTokens": 8192,
+      "averageLatencyMs": 1800,
+      "supportsJson": true,
+      "invocation": ["ollama", "run", "gemma3-heretic:4b-q4km"],
+      "capabilities": {
+        "conversation": 0.84,
+        "instruction_following": 0.84,
+        "safety": 0.74,
+        "speed": 0.95,
+        "retrieval": 0.64,
+        "summarization": 0.72,
+        "reasoning": 0.91,
+        "coding": 0.82
+      },
+      "tags": ["local", "private", "baseline"]
+    },
+    {
+      "modelId": "cli-codex-high",
+      "provider": "cli",
+      "privacyLevel": "remote",
+      "contextWindowTokens": 128000,
+      "averageLatencyMs": 7000,
+      "inputCostPer1k": 0.02,
+      "outputCostPer1k": 0.08,
+      "supportsJson": true,
+      "supportsTools": true,
+      "invocation": ["codex", "--model", "gpt-5.4"],
+      "capabilities": {
+        "conversation": 0.88,
+        "instruction_following": 0.94,
+        "safety": 0.86,
+        "speed": 0.72,
+        "retrieval": 0.82,
+        "summarization": 0.9,
+        "reasoning": 0.96,
+        "coding": 0.95
+      },
+      "tags": ["cli", "coding", "reasoning"]
+    },
+    {
+      "modelId": "api-long-context-memory",
+      "provider": "api",
+      "privacyLevel": "remote",
+      "contextWindowTokens": 200000,
+      "averageLatencyMs": 5000,
+      "inputCostPer1k": 0.004,
+      "outputCostPer1k": 0.012,
+      "supportsJson": true,
+      "capabilities": {
+        "conversation": 0.84,
+        "instruction_following": 0.86,
+        "safety": 0.83,
+        "speed": 0.78,
+        "retrieval": 0.95,
+        "summarization": 0.93,
+        "reasoning": 0.84,
+        "coding": 0.72
+      },
+      "tags": ["api", "memory", "long-context"]
+    }
+  ]
+}

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -11,14 +11,18 @@ from .model_router import (
     select_character_panel,
     select_model,
 )
+from .model_registry import RegistryError, load_model_registry, parse_model_registry
 
 __all__ = [
     "CharacterPanelSelection",
     "ModelEndpoint",
     "ModelScore",
     "RouterError",
+    "RegistryError",
     "TaskProfile",
     "default_character_role_tasks",
+    "load_model_registry",
+    "parse_model_registry",
     "rank_models",
     "select_character_panel",
     "select_model",

--- a/furyoku/model_registry.py
+++ b/furyoku/model_registry.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .model_router import ModelEndpoint
+
+
+class RegistryError(ValueError):
+    """Raised when a model registry file is malformed."""
+
+
+def load_model_registry(path: str | Path) -> list[ModelEndpoint]:
+    registry_path = Path(path)
+    with registry_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return parse_model_registry(payload, source=str(registry_path))
+
+
+def parse_model_registry(payload: Mapping[str, Any], *, source: str = "<memory>") -> list[ModelEndpoint]:
+    if not isinstance(payload, Mapping):
+        raise RegistryError(f"{source}: registry must be a JSON object")
+    schema_version = payload.get("schemaVersion", payload.get("schema_version", 1))
+    if schema_version != 1:
+        raise RegistryError(f"{source}: unsupported registry schemaVersion {schema_version!r}")
+
+    raw_models = payload.get("models", payload.get("endpoints"))
+    if not isinstance(raw_models, list) or not raw_models:
+        raise RegistryError(f"{source}: registry must contain a non-empty models array")
+
+    models = [_parse_model_endpoint(raw, source=source, index=index) for index, raw in enumerate(raw_models)]
+    model_ids = [model.model_id for model in models]
+    duplicates = sorted({model_id for model_id in model_ids if model_ids.count(model_id) > 1})
+    if duplicates:
+        raise RegistryError(f"{source}: duplicate model ids: {', '.join(duplicates)}")
+    return models
+
+
+def _parse_model_endpoint(raw: Mapping[str, Any], *, source: str, index: int) -> ModelEndpoint:
+    if not isinstance(raw, Mapping):
+        raise RegistryError(f"{source}: models[{index}] must be a JSON object")
+
+    model_id = _required_str(raw, "modelId", "model_id", source=source, index=index)
+    provider = _required_str(raw, "provider", source=source, index=index)
+    capabilities = raw.get("capabilities")
+    if not isinstance(capabilities, Mapping) or not capabilities:
+        raise RegistryError(f"{source}: models[{index}] must define non-empty capabilities")
+
+    context_window_tokens = _required_int(raw, "contextWindowTokens", "context_window_tokens", source=source, index=index)
+    average_latency_ms = _required_int(raw, "averageLatencyMs", "average_latency_ms", source=source, index=index)
+    invocation = raw.get("invocation", [])
+    if invocation is None:
+        invocation = []
+    if not isinstance(invocation, list):
+        raise RegistryError(f"{source}: models[{index}].invocation must be an array when provided")
+
+    return ModelEndpoint(
+        model_id=model_id,
+        provider=provider,
+        capabilities={str(key): float(value) for key, value in capabilities.items()},
+        context_window_tokens=context_window_tokens,
+        average_latency_ms=average_latency_ms,
+        input_cost_per_1k=float(raw.get("inputCostPer1k", raw.get("input_cost_per_1k", 0.0)) or 0.0),
+        output_cost_per_1k=float(raw.get("outputCostPer1k", raw.get("output_cost_per_1k", 0.0)) or 0.0),
+        available=bool(raw.get("available", True)),
+        privacy_level=str(raw.get("privacyLevel", raw.get("privacy_level", "remote"))),
+        invocation=tuple(str(item) for item in invocation),
+        supports_tools=bool(raw.get("supportsTools", raw.get("supports_tools", False))),
+        supports_json=bool(raw.get("supportsJson", raw.get("supports_json", False))),
+        tags=tuple(str(item) for item in raw.get("tags", ())),
+    )
+
+
+def _required_str(raw: Mapping[str, Any], *keys: str, source: str, index: int) -> str:
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise RegistryError(f"{source}: models[{index}] missing required field {keys[0]}")
+
+
+def _required_int(raw: Mapping[str, Any], *keys: str, source: str, index: int) -> int:
+    for key in keys:
+        value = raw.get(key)
+        if value not in (None, ""):
+            try:
+                integer_value = int(value)
+            except (TypeError, ValueError) as exc:
+                raise RegistryError(f"{source}: models[{index}].{key} must be an integer") from exc
+            if integer_value < 0:
+                raise RegistryError(f"{source}: models[{index}].{key} must be non-negative")
+            return integer_value
+    raise RegistryError(f"{source}: models[{index}] missing required field {keys[0]}")

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,81 @@
+import unittest
+from pathlib import Path
+
+from furyoku import RegistryError, load_model_registry, parse_model_registry, select_character_panel, select_model
+from furyoku.model_router import TaskProfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_REGISTRY = ROOT / "examples" / "model_registry.example.json"
+
+
+class ModelRegistryTests(unittest.TestCase):
+    def test_load_example_registry_for_character_panel(self):
+        models = load_model_registry(EXAMPLE_REGISTRY)
+
+        panel = select_character_panel(models, allow_reuse=False)
+
+        self.assertEqual(panel.face.model.model_id, "cli-codex-high")
+        self.assertEqual(panel.memory.model.model_id, "api-long-context-memory")
+        self.assertEqual(panel.reasoning.model.model_id, "local-gemma3-heretic-q4")
+
+    def test_registry_drives_local_only_selection(self):
+        models = load_model_registry(EXAMPLE_REGISTRY)
+        task = TaskProfile(
+            task_id="private-local-response",
+            required_capabilities={"conversation": 0.8, "instruction_following": 0.8},
+            privacy_requirement="local_only",
+        )
+
+        selected = select_model(models, task)
+
+        self.assertEqual(selected.model.provider, "local")
+        self.assertEqual(selected.model.invocation[0], "ollama")
+
+    def test_duplicate_model_ids_are_rejected(self):
+        payload = {
+            "schemaVersion": 1,
+            "models": [
+                {
+                    "modelId": "duplicate",
+                    "provider": "local",
+                    "contextWindowTokens": 1000,
+                    "averageLatencyMs": 10,
+                    "capabilities": {"conversation": 1.0},
+                },
+                {
+                    "modelId": "duplicate",
+                    "provider": "api",
+                    "contextWindowTokens": 1000,
+                    "averageLatencyMs": 10,
+                    "capabilities": {"conversation": 1.0},
+                },
+            ],
+        }
+
+        with self.assertRaises(RegistryError) as error:
+            parse_model_registry(payload)
+
+        self.assertIn("duplicate model ids", str(error.exception))
+
+    def test_missing_capabilities_are_rejected(self):
+        payload = {
+            "schemaVersion": 1,
+            "models": [
+                {
+                    "modelId": "broken",
+                    "provider": "local",
+                    "contextWindowTokens": 1000,
+                    "averageLatencyMs": 10,
+                },
+            ],
+        }
+
+        with self.assertRaises(RegistryError) as error:
+            parse_model_registry(payload)
+
+        self.assertIn("capabilities", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds JSON-backed model registry loading for local, CLI, and API router endpoints. Includes validation, duplicate detection, an example registry, exported loader APIs, and tests proving configured endpoints can drive local-only selection and three-role CHARACTER panel selection. Verification: python -m py_compile furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest tests.test_model_router tests.test_model_registry; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #76.