### PR TITLE
Generalize CHARACTER composition selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current primary lane: [#74](https://github.com/JKhyro/FURYOKU/issues/74)
+- Current primary lane: [#78](https://github.com/JKhyro/FURYOKU/issues/78)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
 ## Current Baseline
@@ -22,24 +22,24 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: Native C core/runtime first; Avalonia only as a thin shell through native C interop; C# only where necessary for host/binding glue
-- Current follow-on focus: build a multi-model router that can choose the best local, CLI, or API LLM for a task and later feed CHARACTER/MOA-style agent arrays.
+- Current follow-on focus: add provider adapters so the router can execute local, CLI, and API LLMs through one interface.
 
 ## Product Direction
 
-FURYOKU's primary job is to help the wider system choose the right LLM for the situation.
+FURYOKU's currently known job is to help the wider system choose and use the right LLM for the situation. This is the current implementation horizon, not the final long-term definition of the project.
 
 - Register multiple model endpoints: local models, command-line/CLI models, and remote API models.
 - Describe task requirements such as privacy, reasoning, coding, memory retrieval, context size, latency, tool support, and structured output.
 - Rank eligible models and explain why a model was selected or rejected.
-- Support three-role CHARACTER panels where one model can act as the interactive face, one as memory/retrieval support, and one as reasoning/coding/rationality support.
+- Support flexible CHARACTER compositions, from a one-role tertiary Symbiote to larger arrays such as a primary role plus multiple secondary roles with their own subagent capacity.
 - Use benchmark truth as evidence for routing decisions, not as the project goal by itself.
 
 Current routing core:
 
-- [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract.
+- [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract and flexible CHARACTER composition selection.
 - [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
-- [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, and three-role CHARACTER panel selection.
+- [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, flexible CHARACTER composition, and the three-role compatibility helper.
 - [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
 
 ## Benchmark Evidence Lane

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -1,20 +1,25 @@
 """FURYOKU multi-model routing primitives."""
 
 from .model_router import (
+    CharacterCompositionSelection,
     CharacterPanelSelection,
+    CharacterRoleSpec,
     ModelEndpoint,
     ModelScore,
     RouterError,
     TaskProfile,
     default_character_role_tasks,
     rank_models,
+    select_character_composition,
     select_character_panel,
     select_model,
 )
 from .model_registry import RegistryError, load_model_registry, parse_model_registry
 
 __all__ = [
+    "CharacterCompositionSelection",
     "CharacterPanelSelection",
+    "CharacterRoleSpec",
     "ModelEndpoint",
     "ModelScore",
     "RouterError",
@@ -24,6 +29,7 @@ __all__ = [
     "load_model_registry",
     "parse_model_registry",
     "rank_models",
+    "select_character_composition",
     "select_character_panel",
     "select_model",
 ]

--- a/furyoku/model_router.py
+++ b/furyoku/model_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Iterable, Mapping
 
 
@@ -65,8 +65,36 @@ class ModelScore:
 
 
 @dataclass(frozen=True)
+class CharacterRoleSpec:
+    """One role inside a flexible CHARACTER composition."""
+
+    role_id: str
+    task: TaskProfile
+    primary: bool = False
+    max_subagents: int = 0
+
+
+@dataclass(frozen=True)
+class CharacterCompositionSelection:
+    """Flexible role selection for a CHARACTER/MOA-style agent array."""
+
+    roles: Mapping[str, ModelScore]
+    role_specs: Mapping[str, CharacterRoleSpec]
+    primary_role: str | None = None
+
+    def as_dict(self) -> dict[str, ModelScore]:
+        return dict(self.roles)
+
+    def max_subagents_for(self, role_id: str) -> int:
+        spec = self.role_specs.get(role_id)
+        if spec is None:
+            raise RouterError(f"Unknown CHARACTER role '{role_id}'")
+        return spec.max_subagents
+
+
+@dataclass(frozen=True)
 class CharacterPanelSelection:
-    """Three-role selection for a CHARACTER/MOA-style agent array."""
+    """Backward-compatible three-role selection for the earlier example panel."""
 
     face: ModelScore
     memory: ModelScore
@@ -205,6 +233,33 @@ def select_model(models: Iterable[ModelEndpoint], task: TaskProfile) -> ModelSco
     raise RouterError(f"No eligible model for task '{task.task_id}'. {blocker_summary}")
 
 
+def select_character_composition(
+    models: Iterable[ModelEndpoint],
+    roles: Iterable[CharacterRoleSpec] | Mapping[str, TaskProfile],
+    *,
+    allow_reuse: bool = True,
+) -> CharacterCompositionSelection:
+    role_specs = _normalize_character_role_specs(roles)
+    remaining_models = list(models)
+    selections: dict[str, ModelScore] = {}
+
+    for spec in _selection_order(role_specs):
+        selected = select_model(remaining_models, spec.task)
+        selections[spec.role_id] = selected
+        if not allow_reuse:
+            remaining_models = [
+                model for model in remaining_models if model.model_id != selected.model.model_id
+            ]
+
+    primary_roles = [spec.role_id for spec in role_specs if spec.primary]
+    primary_role = primary_roles[0] if primary_roles else role_specs[0].role_id
+    return CharacterCompositionSelection(
+        roles=selections,
+        role_specs={spec.role_id: spec for spec in role_specs},
+        primary_role=primary_role,
+    )
+
+
 def select_character_panel(
     models: Iterable[ModelEndpoint],
     role_tasks: Mapping[str, TaskProfile] | None = None,
@@ -216,21 +271,59 @@ def select_character_panel(
     if missing_roles:
         raise RouterError(f"Missing CHARACTER role task profiles: {', '.join(sorted(missing_roles))}")
 
-    remaining_models = list(models)
-    selections: dict[str, ModelScore] = {}
-    for role in ("face", "memory", "reasoning"):
-        selected = select_model(remaining_models, tasks[role])
-        selections[role] = selected
-        if not allow_reuse:
-            remaining_models = [
-                model for model in remaining_models if model.model_id != selected.model.model_id
-            ]
+    composition = select_character_composition(
+        models,
+        [
+            CharacterRoleSpec("face", tasks["face"], primary=True),
+            CharacterRoleSpec("memory", tasks["memory"], max_subagents=12),
+            CharacterRoleSpec("reasoning", tasks["reasoning"], max_subagents=12),
+        ],
+        allow_reuse=allow_reuse,
+    )
 
     return CharacterPanelSelection(
-        face=selections["face"],
-        memory=selections["memory"],
-        reasoning=selections["reasoning"],
+        face=composition.roles["face"],
+        memory=composition.roles["memory"],
+        reasoning=composition.roles["reasoning"],
     )
+
+
+def _normalize_character_role_specs(
+    roles: Iterable[CharacterRoleSpec] | Mapping[str, TaskProfile],
+) -> list[CharacterRoleSpec]:
+    if isinstance(roles, Mapping):
+        role_specs = [
+            CharacterRoleSpec(role_id=str(role_id), task=task, primary=index == 0)
+            for index, (role_id, task) in enumerate(roles.items())
+        ]
+    else:
+        role_specs = list(roles)
+
+    if not role_specs:
+        raise RouterError("CHARACTER composition requires at least one role")
+
+    seen: set[str] = set()
+    primary_count = 0
+    for spec in role_specs:
+        if not spec.role_id.strip():
+            raise RouterError("CHARACTER role ids must be non-empty")
+        if spec.role_id in seen:
+            raise RouterError(f"Duplicate CHARACTER role id '{spec.role_id}'")
+        if spec.max_subagents < 0:
+            raise RouterError(f"CHARACTER role '{spec.role_id}' has negative max_subagents")
+        if spec.primary:
+            primary_count += 1
+        seen.add(spec.role_id)
+
+    if primary_count > 1:
+        raise RouterError("CHARACTER composition can only mark one primary role")
+    return role_specs
+
+
+def _selection_order(role_specs: list[CharacterRoleSpec]) -> list[CharacterRoleSpec]:
+    primary_specs = [spec for spec in role_specs if spec.primary]
+    secondary_specs = [spec for spec in role_specs if not spec.primary]
+    return primary_specs + secondary_specs if primary_specs else role_specs
 
 
 def _weighted_capability_score(model: ModelEndpoint, task: TaskProfile) -> float:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,7 +1,15 @@
 import unittest
 from pathlib import Path
 
-from furyoku import RegistryError, load_model_registry, parse_model_registry, select_character_panel, select_model
+from furyoku import (
+    CharacterRoleSpec,
+    RegistryError,
+    load_model_registry,
+    parse_model_registry,
+    select_character_composition,
+    select_character_panel,
+    select_model,
+)
 from furyoku.model_router import TaskProfile
 
 
@@ -31,6 +39,22 @@ class ModelRegistryTests(unittest.TestCase):
 
         self.assertEqual(selected.model.provider, "local")
         self.assertEqual(selected.model.invocation[0], "ollama")
+
+    def test_registry_drives_single_role_character_composition(self):
+        models = load_model_registry(EXAMPLE_REGISTRY)
+        task = TaskProfile(
+            task_id="symbiote.tertiary.primary",
+            required_capabilities={"conversation": 0.8, "instruction_following": 0.8},
+            privacy_requirement="local_only",
+        )
+
+        composition = select_character_composition(
+            models,
+            [CharacterRoleSpec("primary", task, primary=True)],
+        )
+
+        self.assertEqual(composition.primary_role, "primary")
+        self.assertEqual(composition.roles["primary"].model.model_id, "local-gemma3-heretic-q4")
 
     def test_duplicate_model_ids_are_rejected(self):
         payload = {

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,10 +1,12 @@
 import unittest
 
 from furyoku import (
+    CharacterRoleSpec,
     ModelEndpoint,
     RouterError,
     TaskProfile,
     rank_models,
+    select_character_composition,
     select_character_panel,
     select_model,
 )
@@ -127,6 +129,75 @@ class ModelRouterTests(unittest.TestCase):
         self.assertEqual(panel.memory.model.model_id, "api-long-context-memory")
         self.assertEqual(panel.reasoning.model.model_id, "local-gemma3-heretic-q4")
         self.assertEqual(len({score.model.model_id for score in panel.as_dict().values()}), 3)
+
+    def test_character_composition_supports_single_role_tertiary_symbiote(self):
+        composition = select_character_composition(
+            sample_models(),
+            [
+                CharacterRoleSpec(
+                    "primary",
+                    TaskProfile(
+                        task_id="symbiote.tertiary.primary",
+                        required_capabilities={
+                            "conversation": 0.75,
+                            "instruction_following": 0.75,
+                        },
+                        privacy_requirement="local_only",
+                    ),
+                    primary=True,
+                )
+            ],
+        )
+
+        self.assertEqual(composition.primary_role, "primary")
+        self.assertEqual(list(composition.roles), ["primary"])
+        self.assertEqual(composition.roles["primary"].model.model_id, "local-gemma3-heretic-q4")
+        self.assertEqual(composition.max_subagents_for("primary"), 0)
+
+    def test_character_composition_supports_large_reused_role_arrays(self):
+        role_specs = [
+            CharacterRoleSpec(
+                "primary",
+                TaskProfile(
+                    task_id="kira.primary",
+                    required_capabilities={"conversation": 0.85, "instruction_following": 0.85},
+                ),
+                primary=True,
+                max_subagents=12,
+            )
+        ]
+        for index in range(1, 8):
+            role_specs.append(
+                CharacterRoleSpec(
+                    f"secondary-{index}",
+                    TaskProfile(
+                        task_id=f"kira.secondary.{index}",
+                        required_capabilities={"reasoning": 0.8, "instruction_following": 0.8},
+                    ),
+                    max_subagents=12,
+                )
+            )
+
+        composition = select_character_composition(sample_models(), role_specs, allow_reuse=True)
+
+        self.assertEqual(composition.primary_role, "primary")
+        self.assertEqual(len(composition.roles), 8)
+        self.assertTrue(all(composition.max_subagents_for(role_id) == 12 for role_id in composition.roles))
+        self.assertEqual(composition.roles["primary"].model.model_id, "cli-codex-high")
+
+    def test_character_composition_rejects_duplicate_roles(self):
+        role_task = TaskProfile(task_id="duplicate", required_capabilities={"conversation": 0.5})
+
+        with self.assertRaises(RouterError) as error:
+            select_character_composition(
+                sample_models(),
+                [
+                    CharacterRoleSpec("primary", role_task, primary=True),
+                    CharacterRoleSpec("primary", role_task),
+                ],
+            )
+
+        self.assertIn("Duplicate CHARACTER role id", str(error.exception))
 
     def test_no_eligible_model_raises_with_blocker_summary(self):
         task = TaskProfile(


### PR DESCRIPTION
Corrects the CHARACTER routing abstraction so the earlier three-role panel is treated as an example, not the fixed model. Adds flexible CharacterRoleSpec and CharacterCompositionSelection support for one-role tertiary Symbiotes, larger CHARACTER role arrays, primary-role metadata, and per-role max subagent capacity. Keeps select_character_panel as a compatibility wrapper over the general composition selector. Verification: python -m py_compile furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest tests.test_model_router tests.test_model_registry; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #79.