### PR TITLE
Add provider adapter execution contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: Native C core/runtime first; Avalonia only as a thin shell through native C interop; C# only where necessary for host/binding glue
-- Current follow-on focus: add provider adapters so the router can execute local, CLI, and API LLMs through one interface.
+- Current follow-on focus: connect provider adapters to concrete local, CLI, and API transports so routed endpoints can execute in real operator/runtime flows.
 
 ## Product Direction
 
@@ -38,9 +38,11 @@ Current routing core:
 
 - [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract and flexible CHARACTER composition selection.
 - [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
+- [`furyoku/provider_adapters.py`](furyoku/provider_adapters.py) executes selected local, CLI, and API endpoints through one observable result contract.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
 - [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, flexible CHARACTER composition, and the three-role compatibility helper.
 - [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
+- [`tests/test_provider_adapters.py`](tests/test_provider_adapters.py) verifies subprocess, API transport, timeout, failure, unsupported-provider, and router-selected execution paths.
 
 ## Benchmark Evidence Lane
 

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -15,17 +15,35 @@ from .model_router import (
     select_model,
 )
 from .model_registry import RegistryError, load_model_registry, parse_model_registry
+from .provider_adapters import (
+    ApiProviderAdapter,
+    ProviderAdapterError,
+    ProviderExecutionRequest,
+    ProviderExecutionResult,
+    SubprocessProviderAdapter,
+    default_provider_adapters,
+    execute_model,
+    execute_selected_model,
+)
 
 __all__ = [
+    "ApiProviderAdapter",
     "CharacterCompositionSelection",
     "CharacterPanelSelection",
     "CharacterRoleSpec",
     "ModelEndpoint",
     "ModelScore",
+    "ProviderAdapterError",
+    "ProviderExecutionRequest",
+    "ProviderExecutionResult",
     "RouterError",
     "RegistryError",
+    "SubprocessProviderAdapter",
     "TaskProfile",
     "default_character_role_tasks",
+    "default_provider_adapters",
+    "execute_model",
+    "execute_selected_model",
     "load_model_registry",
     "parse_model_registry",
     "rank_models",

--- a/furyoku/provider_adapters.py
+++ b/furyoku/provider_adapters.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Protocol
+
+from .model_router import ModelEndpoint, ModelScore
+
+
+class ProviderAdapterError(ValueError):
+    """Raised when FURYOKU cannot resolve an execution adapter for a model."""
+
+
+@dataclass(frozen=True)
+class ProviderExecutionRequest:
+    """Input passed to a selected model endpoint."""
+
+    prompt: str
+    timeout_seconds: float | None = 60.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderExecutionResult:
+    """Observed result of one model endpoint execution."""
+
+    model_id: str
+    provider: str
+    status: str
+    response_text: str = ""
+    elapsed_ms: int = 0
+    exit_code: int | None = None
+    stderr: str = ""
+    error: str = ""
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok" and not self.timed_out
+
+
+class ProviderAdapter(Protocol):
+    def execute(
+        self,
+        endpoint: ModelEndpoint,
+        request: ProviderExecutionRequest,
+    ) -> ProviderExecutionResult:
+        """Execute one endpoint and return an observable result."""
+
+
+SubprocessRunner = Callable[
+    [tuple[str, ...], str, float | None],
+    subprocess.CompletedProcess[str],
+]
+ApiTransport = Callable[[ModelEndpoint, ProviderExecutionRequest], Mapping[str, Any] | str | ProviderExecutionResult]
+
+
+class SubprocessProviderAdapter:
+    """Adapter for local and CLI providers backed by command execution."""
+
+    def __init__(self, runner: SubprocessRunner | None = None) -> None:
+        self._runner = runner or _run_subprocess
+
+    def execute(
+        self,
+        endpoint: ModelEndpoint,
+        request: ProviderExecutionRequest,
+    ) -> ProviderExecutionResult:
+        if not endpoint.invocation:
+            return _error_result(endpoint, "subprocess-backed endpoints require invocation")
+
+        started = time.perf_counter()
+        try:
+            completed = self._runner(endpoint.invocation, request.prompt, request.timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            return ProviderExecutionResult(
+                model_id=endpoint.model_id,
+                provider=endpoint.provider,
+                status="timeout",
+                response_text=_coerce_text(exc.stdout),
+                elapsed_ms=_elapsed_ms(started),
+                stderr=_coerce_text(exc.stderr),
+                error=f"execution timed out after {exc.timeout} seconds",
+                timed_out=True,
+            )
+        except OSError as exc:
+            return _error_result(endpoint, str(exc), elapsed_ms=_elapsed_ms(started))
+
+        status = "ok" if completed.returncode == 0 else "error"
+        return ProviderExecutionResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status=status,
+            response_text=completed.stdout or "",
+            elapsed_ms=_elapsed_ms(started),
+            exit_code=completed.returncode,
+            stderr=completed.stderr or "",
+            error="" if completed.returncode == 0 else f"provider exited with code {completed.returncode}",
+        )
+
+
+class ApiProviderAdapter:
+    """Adapter for remote/API providers with an injected transport seam."""
+
+    def __init__(self, transport: ApiTransport | None = None) -> None:
+        self._transport = transport
+
+    def execute(
+        self,
+        endpoint: ModelEndpoint,
+        request: ProviderExecutionRequest,
+    ) -> ProviderExecutionResult:
+        if self._transport is None:
+            return _error_result(endpoint, "api transport is required for API provider execution")
+
+        started = time.perf_counter()
+        try:
+            payload = self._transport(endpoint, request)
+        except TimeoutError as exc:
+            return ProviderExecutionResult(
+                model_id=endpoint.model_id,
+                provider=endpoint.provider,
+                status="timeout",
+                elapsed_ms=_elapsed_ms(started),
+                error=str(exc) or "api execution timed out",
+                timed_out=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - transports must report observable failure to callers.
+            return _error_result(endpoint, str(exc), elapsed_ms=_elapsed_ms(started))
+
+        if isinstance(payload, ProviderExecutionResult):
+            return payload
+        if isinstance(payload, str):
+            return ProviderExecutionResult(
+                model_id=endpoint.model_id,
+                provider=endpoint.provider,
+                status="ok",
+                response_text=payload,
+                elapsed_ms=_elapsed_ms(started),
+            )
+        return ProviderExecutionResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status=str(payload.get("status", "ok")),
+            response_text=str(payload.get("response_text", payload.get("text", "")) or ""),
+            elapsed_ms=int(payload.get("elapsed_ms", _elapsed_ms(started)) or 0),
+            exit_code=_optional_int(payload.get("exit_code")),
+            stderr=str(payload.get("stderr", "") or ""),
+            error=str(payload.get("error", "") or ""),
+            timed_out=bool(payload.get("timed_out", False)),
+        )
+
+
+def default_provider_adapters(
+    *,
+    subprocess_runner: SubprocessRunner | None = None,
+    api_transport: ApiTransport | None = None,
+) -> dict[str, ProviderAdapter]:
+    subprocess_adapter = SubprocessProviderAdapter(subprocess_runner)
+    return {
+        "local": subprocess_adapter,
+        "cli": subprocess_adapter,
+        "api": ApiProviderAdapter(api_transport),
+    }
+
+
+def execute_model(
+    endpoint: ModelEndpoint,
+    request: ProviderExecutionRequest | str,
+    *,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> ProviderExecutionResult:
+    resolved_request = request if isinstance(request, ProviderExecutionRequest) else ProviderExecutionRequest(request)
+    resolved_adapters = adapters or default_provider_adapters()
+    adapter = resolved_adapters.get(endpoint.provider)
+    if adapter is None:
+        raise ProviderAdapterError(f"Unsupported provider '{endpoint.provider}' for model '{endpoint.model_id}'")
+    return adapter.execute(endpoint, resolved_request)
+
+
+def execute_selected_model(
+    selection: ModelScore,
+    request: ProviderExecutionRequest | str,
+    *,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> ProviderExecutionResult:
+    return execute_model(selection.model, request, adapters=adapters)
+
+
+def _run_subprocess(
+    invocation: tuple[str, ...],
+    prompt: str,
+    timeout_seconds: float | None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(invocation),
+        input=prompt,
+        text=True,
+        capture_output=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def _error_result(endpoint: ModelEndpoint, error: str, *, elapsed_ms: int = 0) -> ProviderExecutionResult:
+    return ProviderExecutionResult(
+        model_id=endpoint.model_id,
+        provider=endpoint.provider,
+        status="error",
+        elapsed_ms=elapsed_ms,
+        error=error,
+    )
+
+
+def _coerce_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _elapsed_ms(started: float) -> int:
+    return max(0, int(round((time.perf_counter() - started) * 1000)))
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    return int(value)

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,0 +1,166 @@
+import subprocess
+import unittest
+
+from furyoku import (
+    ApiProviderAdapter,
+    ModelEndpoint,
+    ProviderAdapterError,
+    ProviderExecutionRequest,
+    SubprocessProviderAdapter,
+    TaskProfile,
+    execute_model,
+    execute_selected_model,
+    select_model,
+)
+
+
+def local_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="local-echo",
+        provider="local",
+        privacy_level="local",
+        context_window_tokens=4096,
+        average_latency_ms=10,
+        invocation=("echo-model", "--json"),
+        capabilities={"conversation": 1.0, "instruction_following": 1.0},
+        supports_json=True,
+    )
+
+
+def cli_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="cli-coder",
+        provider="cli",
+        privacy_level="remote",
+        context_window_tokens=128000,
+        average_latency_ms=20,
+        invocation=("codex", "--model", "test"),
+        capabilities={"coding": 1.0, "reasoning": 1.0},
+        supports_tools=True,
+    )
+
+
+def api_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="api-memory",
+        provider="api",
+        privacy_level="remote",
+        context_window_tokens=200000,
+        average_latency_ms=30,
+        capabilities={"retrieval": 1.0, "summarization": 1.0},
+        supports_json=True,
+    )
+
+
+class ProviderAdapterTests(unittest.TestCase):
+    def test_subprocess_adapter_success_captures_stdout_and_exit_code(self):
+        calls = []
+
+        def runner(invocation, prompt, timeout):
+            calls.append((invocation, prompt, timeout))
+            return subprocess.CompletedProcess(invocation, 0, stdout="model response", stderr="")
+
+        result = SubprocessProviderAdapter(runner).execute(
+            local_endpoint(),
+            ProviderExecutionRequest("hello", timeout_seconds=3.0),
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.response_text, "model response")
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.model_id, "local-echo")
+        self.assertEqual(calls, [((("echo-model", "--json")), "hello", 3.0)])
+
+    def test_subprocess_adapter_nonzero_returns_error_result(self):
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 2, stdout="", stderr="bad prompt")
+
+        result = SubprocessProviderAdapter(runner).execute(
+            cli_endpoint(),
+            ProviderExecutionRequest("hello"),
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status, "error")
+        self.assertEqual(result.exit_code, 2)
+        self.assertEqual(result.stderr, "bad prompt")
+        self.assertIn("code 2", result.error)
+
+    def test_subprocess_adapter_timeout_returns_timeout_result(self):
+        def runner(invocation, prompt, timeout):
+            raise subprocess.TimeoutExpired(invocation, timeout, output=b"partial", stderr=b"late")
+
+        result = SubprocessProviderAdapter(runner).execute(
+            local_endpoint(),
+            ProviderExecutionRequest("hello", timeout_seconds=0.01),
+        )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(result.timed_out)
+        self.assertEqual(result.status, "timeout")
+        self.assertEqual(result.response_text, "partial")
+        self.assertEqual(result.stderr, "late")
+
+    def test_execute_model_rejects_unsupported_provider(self):
+        endpoint = ModelEndpoint(
+            model_id="unknown",
+            provider="browser",
+            capabilities={"conversation": 1.0},
+            context_window_tokens=1000,
+            average_latency_ms=10,
+        )
+
+        with self.assertRaises(ProviderAdapterError) as error:
+            execute_model(endpoint, "hello")
+
+        self.assertIn("Unsupported provider", str(error.exception))
+
+    def test_api_adapter_success_uses_injected_transport(self):
+        def transport(endpoint, request):
+            return {"response_text": f"{endpoint.model_id}: {request.prompt}", "status": "ok"}
+
+        result = ApiProviderAdapter(transport).execute(
+            api_endpoint(),
+            ProviderExecutionRequest("retrieve memory"),
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.response_text, "api-memory: retrieve memory")
+        self.assertEqual(result.provider, "api")
+
+    def test_api_adapter_failure_returns_error_result(self):
+        def transport(endpoint, request):
+            raise RuntimeError("api unavailable")
+
+        result = ApiProviderAdapter(transport).execute(
+            api_endpoint(),
+            ProviderExecutionRequest("retrieve memory"),
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status, "error")
+        self.assertEqual(result.error, "api unavailable")
+
+    def test_execute_selected_model_runs_router_selected_endpoint(self):
+        models = [local_endpoint(), cli_endpoint()]
+        selection = select_model(
+            models,
+            TaskProfile("private-chat", {"conversation": 0.9}, privacy_requirement="local_only"),
+        )
+
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"selected: {prompt}", stderr="")
+
+        result = execute_selected_model(
+            selection,
+            "hello",
+            adapters={"local": SubprocessProviderAdapter(runner)},
+        )
+
+        self.assertEqual(result.model_id, "local-echo")
+        self.assertEqual(result.response_text, "selected: hello")
+        self.assertTrue(result.ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the FURYOKU provider execution contract for local, CLI, and API model endpoints. Includes mockable subprocess-backed local/CLI adapters, dependency-injected API transport adapter, observable execution results for response/error/timing/timeout state, and helper execution for router-selected models. Verification: python -m py_compile furyoku/provider_adapters.py furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest tests.test_provider_adapters tests.test_model_router tests.test_model_registry; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #78.