### PR TITLE
Add route-and-execute runtime helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: Native C core/runtime first; Avalonia only as a thin shell through native C interop; C# only where necessary for host/binding glue
-- Current follow-on focus: connect provider adapters to concrete local, CLI, and API transports so routed endpoints can execute in real operator/runtime flows.
+- Current follow-on focus: connect concrete local, CLI, and API transports plus operator-facing entrypoints to the route-and-execute runtime flow.
 
 ## Product Direction
 
@@ -39,10 +39,12 @@ Current routing core:
 - [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract and flexible CHARACTER composition selection.
 - [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
 - [`furyoku/provider_adapters.py`](furyoku/provider_adapters.py) executes selected local, CLI, and API endpoints through one observable result contract.
+- [`furyoku/runtime.py`](furyoku/runtime.py) combines task-based routing with provider execution and returns selection evidence plus execution output.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
 - [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, flexible CHARACTER composition, and the three-role compatibility helper.
 - [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
 - [`tests/test_provider_adapters.py`](tests/test_provider_adapters.py) verifies subprocess, API transport, timeout, failure, unsupported-provider, and router-selected execution paths.
+- [`tests/test_runtime.py`](tests/test_runtime.py) verifies route-and-execute success and observable execution failure paths.
 
 ## Benchmark Evidence Lane
 

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -25,6 +25,7 @@ from .provider_adapters import (
     execute_model,
     execute_selected_model,
 )
+from .runtime import RoutedExecutionResult, route_and_execute
 
 __all__ = [
     "ApiProviderAdapter",
@@ -38,6 +39,7 @@ __all__ = [
     "ProviderExecutionResult",
     "RouterError",
     "RegistryError",
+    "RoutedExecutionResult",
     "SubprocessProviderAdapter",
     "TaskProfile",
     "default_character_role_tasks",
@@ -47,6 +49,7 @@ __all__ = [
     "load_model_registry",
     "parse_model_registry",
     "rank_models",
+    "route_and_execute",
     "select_character_composition",
     "select_character_panel",
     "select_model",

--- a/furyoku/runtime.py
+++ b/furyoku/runtime.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .model_router import ModelEndpoint, ModelScore, TaskProfile, select_model
+from .provider_adapters import (
+    ProviderAdapter,
+    ProviderExecutionRequest,
+    ProviderExecutionResult,
+    execute_selected_model,
+)
+
+
+@dataclass(frozen=True)
+class RoutedExecutionResult:
+    """A complete route-and-execute decision for one task."""
+
+    selection: ModelScore
+    execution: ProviderExecutionResult
+
+    @property
+    def ok(self) -> bool:
+        return self.selection.eligible and self.execution.ok
+
+    @property
+    def model_id(self) -> str:
+        return self.selection.model.model_id
+
+    @property
+    def provider(self) -> str:
+        return self.selection.model.provider
+
+
+def route_and_execute(
+    models: list[ModelEndpoint],
+    task: TaskProfile,
+    request: ProviderExecutionRequest | str,
+    *,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> RoutedExecutionResult:
+    """Select the best eligible model for a task, then execute it."""
+
+    selection = select_model(models, task)
+    execution = execute_selected_model(selection, request, adapters=adapters)
+    return RoutedExecutionResult(selection=selection, execution=execution)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,77 @@
+import subprocess
+import unittest
+
+from furyoku import (
+    ModelEndpoint,
+    ProviderExecutionRequest,
+    SubprocessProviderAdapter,
+    TaskProfile,
+    route_and_execute,
+)
+
+
+def local_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="local-chat",
+        provider="local",
+        privacy_level="local",
+        context_window_tokens=4096,
+        average_latency_ms=10,
+        invocation=("local-chat",),
+        capabilities={"conversation": 0.95, "instruction_following": 0.9},
+    )
+
+
+def cli_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="cli-coder",
+        provider="cli",
+        privacy_level="remote",
+        context_window_tokens=128000,
+        average_latency_ms=20,
+        invocation=("cli-coder",),
+        capabilities={"conversation": 0.8, "instruction_following": 0.85, "coding": 0.95},
+    )
+
+
+class RuntimeTests(unittest.TestCase):
+    def test_route_and_execute_returns_selection_and_execution_result(self):
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = route_and_execute(
+            [local_endpoint(), cli_endpoint()],
+            TaskProfile(
+                task_id="private-chat",
+                required_capabilities={"conversation": 0.9},
+                privacy_requirement="local_only",
+            ),
+            "hello",
+            adapters={"local": SubprocessProviderAdapter(runner)},
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.model_id, "local-chat")
+        self.assertEqual(result.provider, "local")
+        self.assertEqual(result.execution.response_text, "local-chat:hello")
+        self.assertGreater(result.selection.score, 0)
+
+    def test_route_and_execute_preserves_execution_failure_observability(self):
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 3, stdout="", stderr="bad runtime")
+
+        result = route_and_execute(
+            [local_endpoint()],
+            TaskProfile(task_id="chat", required_capabilities={"conversation": 0.9}),
+            ProviderExecutionRequest("hello", timeout_seconds=2),
+            adapters={"local": SubprocessProviderAdapter(runner)},
+        )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(result.selection.eligible)
+        self.assertEqual(result.execution.status, "error")
+        self.assertEqual(result.execution.stderr, "bad runtime")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a route-and-execute runtime helper that selects the best eligible model for a task and executes it through the provider adapter layer, returning both selection evidence and observable execution output. Verification: python -m py_compile furyoku/runtime.py furyoku/provider_adapters.py furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest tests.test_runtime tests.test_provider_adapters tests.test_model_router tests.test_model_registry; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #82.