### PR TITLE
Add JSON task profile loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ Current routing core:
 
 - [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract and flexible CHARACTER composition selection.
 - [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
+- [`furyoku/task_profiles.py`](furyoku/task_profiles.py) loads reusable JSON task profiles into router-ready task requirements.
 - [`furyoku/provider_adapters.py`](furyoku/provider_adapters.py) executes selected local, CLI, and API endpoints through one observable result contract.
 - [`furyoku/runtime.py`](furyoku/runtime.py) combines task-based routing with provider execution and returns selection evidence plus execution output.
 - [`furyoku/cli.py`](furyoku/cli.py) provides `select` and `run` commands for registry-backed model routing and execution.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
+- [`examples/task_profile.private-chat.json`](examples/task_profile.private-chat.json) shows reusable task profile configuration.
 - [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, flexible CHARACTER composition, and the three-role compatibility helper.
 - [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
+- [`tests/test_task_profiles.py`](tests/test_task_profiles.py) verifies task profile loading and validation.
 - [`tests/test_provider_adapters.py`](tests/test_provider_adapters.py) verifies subprocess, API transport, timeout, failure, unsupported-provider, and router-selected execution paths.
 - [`tests/test_runtime.py`](tests/test_runtime.py) verifies route-and-execute success and observable execution failure paths.
 - [`tests/test_cli.py`](tests/test_cli.py) verifies operator-facing selection and local execution command paths.
@@ -51,7 +54,7 @@ Current routing core:
 CLI example:
 
 ```powershell
-python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-id private-chat --capability conversation=0.8 --privacy local_only
+python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json
 ```
 
 ## Benchmark Evidence Lane

--- a/examples/task_profile.private-chat.json
+++ b/examples/task_profile.private-chat.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "taskId": "private-chat",
+  "description": "Local/private conversational response with basic instruction following.",
+  "privacyRequirement": "local_only",
+  "requiredCapabilities": {
+    "conversation": 0.8,
+    "instruction_following": 0.75
+  }
+}

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -26,6 +26,7 @@ from .provider_adapters import (
     execute_selected_model,
 )
 from .runtime import RoutedExecutionResult, route_and_execute
+from .task_profiles import TaskProfileError, load_task_profile, parse_task_profile
 
 __all__ = [
     "ApiProviderAdapter",
@@ -42,12 +43,15 @@ __all__ = [
     "RoutedExecutionResult",
     "SubprocessProviderAdapter",
     "TaskProfile",
+    "TaskProfileError",
     "default_character_role_tasks",
     "default_provider_adapters",
     "execute_model",
     "execute_selected_model",
     "load_model_registry",
+    "load_task_profile",
     "parse_model_registry",
+    "parse_task_profile",
     "rank_models",
     "route_and_execute",
     "select_character_composition",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -10,13 +10,14 @@ from .model_registry import load_model_registry
 from .model_router import ModelScore, TaskProfile, select_model
 from .provider_adapters import ProviderExecutionRequest
 from .runtime import RoutedExecutionResult, route_and_execute
+from .task_profiles import load_task_profile
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     models = load_model_registry(args.registry)
-    task = _task_from_args(args)
+    task = _task_from_args(args, parser)
 
     if args.command == "select":
         selection = select_model(models, task)
@@ -49,11 +50,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _add_common_task_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--registry", required=True, type=Path, help="Path to a FURYOKU model registry JSON file.")
-    parser.add_argument("--task-id", required=True, help="Task identifier for routing evidence.")
+    parser.add_argument("--task-profile", type=Path, help="Path to a reusable FURYOKU task profile JSON file.")
+    parser.add_argument("--task-id", help="Task identifier for routing evidence.")
     parser.add_argument(
         "--capability",
         action="append",
-        required=True,
         default=[],
         metavar="NAME=SCORE",
         help="Required capability score from 0.0 to 1.0. Repeat for multiple capabilities.",
@@ -78,7 +79,32 @@ def _add_common_task_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--max-output-cost-per-1k", type=float, default=None, help="Maximum output cost per 1k tokens.")
 
 
-def _task_from_args(args: argparse.Namespace) -> TaskProfile:
+def _task_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> TaskProfile:
+    if args.task_profile:
+        profile = load_task_profile(args.task_profile)
+        if not args.capability and not args.task_id:
+            return profile
+        return TaskProfile(
+            task_id=args.task_id or profile.task_id,
+            description=args.description or profile.description,
+            required_capabilities=_parse_capabilities(args.capability) if args.capability else profile.required_capabilities,
+            min_context_tokens=args.min_context_tokens or profile.min_context_tokens,
+            privacy_requirement=args.privacy if args.privacy != "allow_remote" else profile.privacy_requirement,
+            max_input_cost_per_1k=args.max_input_cost_per_1k
+            if args.max_input_cost_per_1k is not None
+            else profile.max_input_cost_per_1k,
+            max_output_cost_per_1k=args.max_output_cost_per_1k
+            if args.max_output_cost_per_1k is not None
+            else profile.max_output_cost_per_1k,
+            require_tools=args.require_tools or profile.require_tools,
+            require_json=args.require_json or profile.require_json,
+            preferred_providers=tuple(args.preferred_provider) or profile.preferred_providers,
+        )
+
+    if not args.task_id:
+        parser.error("--task-id is required unless --task-profile is provided")
+    if not args.capability:
+        parser.error("--capability is required unless --task-profile is provided")
     return TaskProfile(
         task_id=args.task_id,
         description=args.description,

--- a/furyoku/task_profiles.py
+++ b/furyoku/task_profiles.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .model_router import TaskProfile
+
+
+class TaskProfileError(ValueError):
+    """Raised when a task profile file is malformed."""
+
+
+def load_task_profile(path: str | Path) -> TaskProfile:
+    profile_path = Path(path)
+    with profile_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return parse_task_profile(payload, source=str(profile_path))
+
+
+def parse_task_profile(payload: Mapping[str, Any], *, source: str = "<memory>") -> TaskProfile:
+    if not isinstance(payload, Mapping):
+        raise TaskProfileError(f"{source}: task profile must be a JSON object")
+    schema_version = payload.get("schemaVersion", payload.get("schema_version", 1))
+    if schema_version != 1:
+        raise TaskProfileError(f"{source}: unsupported task profile schemaVersion {schema_version!r}")
+
+    task_id = str(payload.get("taskId", payload.get("task_id", "")) or "").strip()
+    if not task_id:
+        raise TaskProfileError(f"{source}: taskId is required")
+
+    raw_capabilities = payload.get("requiredCapabilities", payload.get("required_capabilities"))
+    if not isinstance(raw_capabilities, Mapping) or not raw_capabilities:
+        raise TaskProfileError(f"{source}: requiredCapabilities must be a non-empty object")
+
+    return TaskProfile(
+        task_id=task_id,
+        description=str(payload.get("description", "") or ""),
+        required_capabilities={str(key): float(value) for key, value in raw_capabilities.items()},
+        min_context_tokens=int(payload.get("minContextTokens", payload.get("min_context_tokens", 0)) or 0),
+        privacy_requirement=str(payload.get("privacyRequirement", payload.get("privacy_requirement", "allow_remote"))),
+        max_input_cost_per_1k=_optional_float(payload.get("maxInputCostPer1k", payload.get("max_input_cost_per_1k"))),
+        max_output_cost_per_1k=_optional_float(payload.get("maxOutputCostPer1k", payload.get("max_output_cost_per_1k"))),
+        require_tools=bool(payload.get("requireTools", payload.get("require_tools", False))),
+        require_json=bool(payload.get("requireJson", payload.get("require_json", False))),
+        preferred_providers=tuple(str(item) for item in payload.get("preferredProviders", payload.get("preferred_providers", ()))),
+    )
+
+
+def _optional_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,16 @@ def write_registry(path: Path) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def write_task_profile(path: Path) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "taskId": "private-chat",
+        "privacyRequirement": "local_only",
+        "requiredCapabilities": {"conversation": 0.9},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 class CliTests(unittest.TestCase):
     def test_select_outputs_selected_model_json(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -103,6 +113,29 @@ class CliTests(unittest.TestCase):
             self.assertTrue(payload["ok"])
             self.assertEqual(payload["selection"]["modelId"], "local-echo")
             self.assertEqual(payload["execution"]["responseText"].strip(), "echo:hello")
+
+    def test_select_accepts_task_profile_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "task.json"
+            write_registry(registry_path)
+            write_task_profile(task_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "select",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["modelId"], "local-echo")
 
 
 if __name__ == "__main__":

--- a/tests/test_task_profiles.py
+++ b/tests/test_task_profiles.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+from furyoku import TaskProfileError, load_task_profile, parse_task_profile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_TASK = ROOT / "examples" / "task_profile.private-chat.json"
+
+
+class TaskProfileTests(unittest.TestCase):
+    def test_load_example_task_profile(self):
+        profile = load_task_profile(EXAMPLE_TASK)
+
+        self.assertEqual(profile.task_id, "private-chat")
+        self.assertEqual(profile.privacy_requirement, "local_only")
+        self.assertEqual(profile.required_capabilities["conversation"], 0.8)
+
+    def test_missing_capabilities_are_rejected(self):
+        with self.assertRaises(TaskProfileError) as error:
+            parse_task_profile({"schemaVersion": 1, "taskId": "broken"})
+
+        self.assertIn("requiredCapabilities", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds reusable JSON task profiles and CLI support for --task-profile so operators can select/run models from named task definitions instead of repeating capability flags. Includes a private-chat example profile and tests for loading, validation, and CLI profile routing. Verification: python -m py_compile furyoku/cli.py furyoku/task_profiles.py furyoku/runtime.py furyoku/provider_adapters.py furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest tests.test_cli tests.test_task_profiles tests.test_runtime tests.test_provider_adapters tests.test_model_router tests.test_model_registry; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #86.