### PR TITLE
Add provider health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 
 FURYOKU's currently known job is to help the wider system choose and use the right LLM for the situation. This is the current implementation horizon, not the final long-term definition of the project.
 
+Scope guard:
+
+- Do not treat benchmark truth or CI support as the project purpose.
+- Keep the primary execution lane on the multi-model local/CLI/API runtime and flexible CHARACTER/MOA foundation unless the user explicitly redirects.
+- Treat benchmark and CI work as supporting evidence and safety infrastructure.
+
 - Register multiple model endpoints: local models, command-line/CLI models, and remote API models.
 - Describe task requirements such as privacy, reasoning, coding, memory retrieval, context size, latency, tool support, and structured output.
 - Rank eligible models and explain why a model was selected or rejected.
@@ -40,14 +46,16 @@ Current routing core:
 - [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
 - [`furyoku/task_profiles.py`](furyoku/task_profiles.py) loads reusable JSON task profiles into router-ready task requirements.
 - [`furyoku/provider_adapters.py`](furyoku/provider_adapters.py) executes selected local, CLI, and API endpoints through one observable result contract.
+- [`furyoku/provider_health.py`](furyoku/provider_health.py) checks registered endpoint readiness before routing work to a provider.
 - [`furyoku/runtime.py`](furyoku/runtime.py) combines task-based routing with provider execution and returns selection evidence plus execution output.
-- [`furyoku/cli.py`](furyoku/cli.py) provides `select` and `run` commands for registry-backed model routing and execution.
+- [`furyoku/cli.py`](furyoku/cli.py) provides `select`, `run`, and `health` commands for registry-backed model routing, execution, and readiness checks.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
 - [`examples/task_profile.private-chat.json`](examples/task_profile.private-chat.json) shows reusable task profile configuration.
 - [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, flexible CHARACTER composition, and the three-role compatibility helper.
 - [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
 - [`tests/test_task_profiles.py`](tests/test_task_profiles.py) verifies task profile loading and validation.
 - [`tests/test_provider_adapters.py`](tests/test_provider_adapters.py) verifies subprocess, API transport, timeout, failure, unsupported-provider, and router-selected execution paths.
+- [`tests/test_provider_health.py`](tests/test_provider_health.py) verifies command resolution, missing invocation, missing transport, probe, and aggregate readiness paths.
 - [`tests/test_runtime.py`](tests/test_runtime.py) verifies route-and-execute success and observable execution failure paths.
 - [`tests/test_cli.py`](tests/test_cli.py) verifies operator-facing selection and local execution command paths.
 
@@ -55,6 +63,7 @@ CLI example:
 
 ```powershell
 python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json
+python -m furyoku.cli health --registry .\examples\model_registry.example.json
 ```
 
 ## Benchmark Evidence Lane

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -25,6 +25,12 @@ from .provider_adapters import (
     execute_model,
     execute_selected_model,
 )
+from .provider_health import (
+    ProviderHealthCheckRequest,
+    ProviderHealthCheckResult,
+    check_provider_health,
+    check_provider_health_many,
+)
 from .runtime import RoutedExecutionResult, route_and_execute
 from .task_profiles import TaskProfileError, load_task_profile, parse_task_profile
 
@@ -38,6 +44,8 @@ __all__ = [
     "ProviderAdapterError",
     "ProviderExecutionRequest",
     "ProviderExecutionResult",
+    "ProviderHealthCheckRequest",
+    "ProviderHealthCheckResult",
     "RouterError",
     "RegistryError",
     "RoutedExecutionResult",
@@ -48,6 +56,8 @@ __all__ = [
     "default_provider_adapters",
     "execute_model",
     "execute_selected_model",
+    "check_provider_health",
+    "check_provider_health_many",
     "load_model_registry",
     "load_task_profile",
     "parse_model_registry",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 from .model_registry import load_model_registry
 from .model_router import ModelScore, TaskProfile, select_model
+from .provider_health import ProviderHealthCheckRequest, ProviderHealthCheckResult, check_provider_health_many
 from .provider_adapters import ProviderExecutionRequest
 from .runtime import RoutedExecutionResult, route_and_execute
 from .task_profiles import load_task_profile
@@ -17,14 +18,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     models = load_model_registry(args.registry)
-    task = _task_from_args(args, parser)
 
     if args.command == "select":
+        task = _task_from_args(args, parser)
         selection = select_model(models, task)
         _write_json(_score_to_dict(selection))
         return 0
 
     if args.command == "run":
+        task = _task_from_args(args, parser)
         result = route_and_execute(
             models,
             task,
@@ -32,6 +34,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         _write_json(_routed_result_to_dict(result))
         return 0 if result.ok else 2
+
+    if args.command == "health":
+        results = check_provider_health_many(
+            models,
+            ProviderHealthCheckRequest(
+                probe=args.probe,
+                probe_prompt=args.probe_prompt,
+                timeout_seconds=args.timeout_seconds,
+            ),
+        )
+        _write_json({"ok": all(result.ready for result in results), "providers": [_health_to_dict(result) for result in results]})
+        return 0 if all(result.ready for result in results) else 2
 
     parser.error(f"unsupported command {args.command}")
     return 2
@@ -45,6 +59,11 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_common_task_args(run_parser)
     run_parser.add_argument("--prompt", required=True, help="Prompt text passed to the selected model.")
     run_parser.add_argument("--timeout-seconds", type=float, default=60.0, help="Execution timeout in seconds.")
+    health_parser = subparsers.add_parser("health", help="Check provider endpoint readiness for a registry.")
+    health_parser.add_argument("--registry", required=True, type=Path, help="Path to a FURYOKU model registry JSON file.")
+    health_parser.add_argument("--probe", action="store_true", help="Run a lightweight probe instead of only checking configuration.")
+    health_parser.add_argument("--probe-prompt", default="", help="Prompt text used when --probe is set.")
+    health_parser.add_argument("--timeout-seconds", type=float, default=5.0, help="Health probe timeout in seconds.")
     return parser
 
 
@@ -166,6 +185,28 @@ def _routed_result_to_dict(result: RoutedExecutionResult) -> dict:
             "timedOut": execution.timed_out,
         },
     }
+
+
+def _health_to_dict(result: ProviderHealthCheckResult) -> dict:
+    payload = {
+        "modelId": result.model_id,
+        "provider": result.provider,
+        "status": result.status,
+        "ready": result.ready,
+        "reason": result.reason,
+        "command": result.command,
+        "resolvedCommand": result.resolved_command,
+    }
+    if result.execution is not None:
+        payload["execution"] = {
+            "status": result.execution.status,
+            "elapsedMs": result.execution.elapsed_ms,
+            "exitCode": result.execution.exit_code,
+            "stderr": result.execution.stderr,
+            "error": result.execution.error,
+            "timedOut": result.execution.timed_out,
+        }
+    return payload
 
 
 def _write_json(payload: dict) -> None:

--- a/furyoku/provider_health.py
+++ b/furyoku/provider_health.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping
+
+from .model_router import ModelEndpoint
+from .provider_adapters import (
+    ApiTransport,
+    ProviderAdapter,
+    ProviderExecutionRequest,
+    ProviderExecutionResult,
+    default_provider_adapters,
+    execute_model,
+)
+
+
+CommandResolver = Callable[[str], str | None]
+
+
+@dataclass(frozen=True)
+class ProviderHealthCheckRequest:
+    """Controls how deeply a provider endpoint is checked."""
+
+    probe: bool = False
+    probe_prompt: str = ""
+    timeout_seconds: float | None = 5.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderHealthCheckResult:
+    """Readiness result for one registered provider endpoint."""
+
+    model_id: str
+    provider: str
+    status: str
+    ready: bool
+    reason: str = ""
+    command: str | None = None
+    resolved_command: str | None = None
+    execution: ProviderExecutionResult | None = None
+
+
+def check_provider_health(
+    endpoint: ModelEndpoint,
+    request: ProviderHealthCheckRequest | None = None,
+    *,
+    command_resolver: CommandResolver | None = None,
+    api_transport: ApiTransport | None = None,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> ProviderHealthCheckResult:
+    resolved_request = request or ProviderHealthCheckRequest()
+    if endpoint.provider in ("local", "cli"):
+        return _check_subprocess_provider(
+            endpoint,
+            resolved_request,
+            command_resolver=command_resolver or shutil.which,
+            adapters=adapters,
+        )
+    if endpoint.provider == "api":
+        return _check_api_provider(
+            endpoint,
+            resolved_request,
+            api_transport=api_transport,
+            adapters=adapters,
+        )
+    return ProviderHealthCheckResult(
+        model_id=endpoint.model_id,
+        provider=endpoint.provider,
+        status="unsupported-provider",
+        ready=False,
+        reason=f"provider '{endpoint.provider}' is not supported by health checks",
+    )
+
+
+def check_provider_health_many(
+    endpoints: Iterable[ModelEndpoint],
+    request: ProviderHealthCheckRequest | None = None,
+    *,
+    command_resolver: CommandResolver | None = None,
+    api_transport: ApiTransport | None = None,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> list[ProviderHealthCheckResult]:
+    return [
+        check_provider_health(
+            endpoint,
+            request,
+            command_resolver=command_resolver,
+            api_transport=api_transport,
+            adapters=adapters,
+        )
+        for endpoint in endpoints
+    ]
+
+
+def _check_subprocess_provider(
+    endpoint: ModelEndpoint,
+    request: ProviderHealthCheckRequest,
+    *,
+    command_resolver: CommandResolver,
+    adapters: Mapping[str, ProviderAdapter] | None,
+) -> ProviderHealthCheckResult:
+    if not endpoint.invocation:
+        return ProviderHealthCheckResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status="missing-invocation",
+            ready=False,
+            reason="local/CLI providers require an invocation command",
+        )
+
+    command = endpoint.invocation[0]
+    resolved_command = command_resolver(command)
+    if not resolved_command:
+        return ProviderHealthCheckResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status="missing-command",
+            ready=False,
+            command=command,
+            reason=f"command '{command}' was not found",
+        )
+
+    if not request.probe:
+        return ProviderHealthCheckResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status="ready",
+            ready=True,
+            command=command,
+            resolved_command=resolved_command,
+            reason="command is available",
+        )
+
+    execution = execute_model(
+        endpoint,
+        ProviderExecutionRequest(
+            request.probe_prompt,
+            timeout_seconds=request.timeout_seconds,
+            metadata=request.metadata,
+        ),
+        adapters=adapters,
+    )
+    return _result_from_execution(endpoint, execution, command=command, resolved_command=resolved_command)
+
+
+def _check_api_provider(
+    endpoint: ModelEndpoint,
+    request: ProviderHealthCheckRequest,
+    *,
+    api_transport: ApiTransport | None,
+    adapters: Mapping[str, ProviderAdapter] | None,
+) -> ProviderHealthCheckResult:
+    if api_transport is None and (adapters is None or "api" not in adapters):
+        return ProviderHealthCheckResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status="missing-transport",
+            ready=False,
+            reason="api health checks require an injected API transport or adapter",
+        )
+
+    if not request.probe:
+        return ProviderHealthCheckResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status="ready",
+            ready=True,
+            reason="api transport is configured",
+        )
+
+    execution = execute_model(
+        endpoint,
+        ProviderExecutionRequest(
+            request.probe_prompt,
+            timeout_seconds=request.timeout_seconds,
+            metadata=request.metadata,
+        ),
+        adapters=adapters or default_provider_adapters(api_transport=api_transport),
+    )
+    return _result_from_execution(endpoint, execution)
+
+
+def _result_from_execution(
+    endpoint: ModelEndpoint,
+    execution: ProviderExecutionResult,
+    *,
+    command: str | None = None,
+    resolved_command: str | None = None,
+) -> ProviderHealthCheckResult:
+    if execution.ok:
+        return ProviderHealthCheckResult(
+            model_id=endpoint.model_id,
+            provider=endpoint.provider,
+            status="ready",
+            ready=True,
+            command=command,
+            resolved_command=resolved_command,
+            reason="probe execution succeeded",
+            execution=execution,
+        )
+    if execution.timed_out:
+        status = "timeout"
+        reason = execution.error or "probe execution timed out"
+    else:
+        status = "probe-failed"
+        reason = execution.error or execution.stderr or "probe execution failed"
+    return ProviderHealthCheckResult(
+        model_id=endpoint.model_id,
+        provider=endpoint.provider,
+        status=status,
+        ready=False,
+        command=command,
+        resolved_command=resolved_command,
+        reason=reason,
+        execution=execution,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,24 @@ def write_task_profile(path: Path) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def write_local_only_registry(path: Path) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "models": [
+            {
+                "modelId": "python-local",
+                "provider": "local",
+                "privacyLevel": "local",
+                "contextWindowTokens": 4096,
+                "averageLatencyMs": 10,
+                "invocation": [sys.executable, "-c", "print('ready')"],
+                "capabilities": {"conversation": 0.9},
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 class CliTests(unittest.TestCase):
     def test_select_outputs_selected_model_json(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -136,6 +154,21 @@ class CliTests(unittest.TestCase):
             payload = json.loads(stdout.getvalue())
             self.assertEqual(exit_code, 0)
             self.assertEqual(payload["modelId"], "local-echo")
+
+    def test_health_reports_registry_provider_readiness(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            write_local_only_registry(registry_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(["health", "--registry", str(registry_path)])
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["providers"][0]["modelId"], "python-local")
+            self.assertEqual(payload["providers"][0]["status"], "ready")
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_health.py
+++ b/tests/test_provider_health.py
@@ -1,0 +1,136 @@
+import unittest
+
+from furyoku import (
+    ModelEndpoint,
+    ProviderHealthCheckRequest,
+    check_provider_health,
+    check_provider_health_many,
+)
+
+
+def local_endpoint(invocation=("furyoku-local", "--probe")) -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="local-ready",
+        provider="local",
+        privacy_level="local",
+        context_window_tokens=4096,
+        average_latency_ms=10,
+        invocation=invocation,
+        capabilities={"conversation": 1.0},
+    )
+
+
+def api_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="api-ready",
+        provider="api",
+        privacy_level="remote",
+        context_window_tokens=128000,
+        average_latency_ms=20,
+        capabilities={"conversation": 1.0},
+    )
+
+
+class ProviderHealthTests(unittest.TestCase):
+    def test_local_command_ready_without_probe(self):
+        result = check_provider_health(
+            local_endpoint(),
+            command_resolver=lambda command: f"C:/tools/{command}.exe",
+        )
+
+        self.assertTrue(result.ready)
+        self.assertEqual(result.status, "ready")
+        self.assertEqual(result.command, "furyoku-local")
+        self.assertEqual(result.resolved_command, "C:/tools/furyoku-local.exe")
+        self.assertIsNone(result.execution)
+
+    def test_local_missing_command(self):
+        result = check_provider_health(
+            local_endpoint(),
+            command_resolver=lambda command: None,
+        )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.status, "missing-command")
+        self.assertEqual(result.command, "furyoku-local")
+        self.assertIn("furyoku-local", result.reason)
+
+    def test_local_missing_invocation(self):
+        result = check_provider_health(
+            local_endpoint(invocation=()),
+            command_resolver=lambda command: f"C:/tools/{command}.exe",
+        )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.status, "missing-invocation")
+        self.assertIsNone(result.command)
+
+    def test_api_no_transport(self):
+        result = check_provider_health(api_endpoint())
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.status, "missing-transport")
+        self.assertIn("transport", result.reason)
+
+    def test_api_probe_success_uses_injected_transport(self):
+        calls = []
+
+        def transport(endpoint, request):
+            calls.append((endpoint.model_id, request.prompt, request.timeout_seconds, request.metadata))
+            return {"status": "ok", "response_text": "healthy"}
+
+        result = check_provider_health(
+            api_endpoint(),
+            ProviderHealthCheckRequest(
+                probe=True,
+                probe_prompt="health",
+                timeout_seconds=1.5,
+                metadata={"check": "provider-health"},
+            ),
+            api_transport=transport,
+        )
+
+        self.assertTrue(result.ready)
+        self.assertEqual(result.status, "ready")
+        self.assertIsNotNone(result.execution)
+        self.assertTrue(result.execution.ok)
+        self.assertEqual(result.execution.response_text, "healthy")
+        self.assertEqual(calls, [("api-ready", "health", 1.5, {"check": "provider-health"})])
+
+    def test_api_probe_failure_reports_not_ready(self):
+        def transport(endpoint, request):
+            raise RuntimeError("api unavailable")
+
+        result = check_provider_health(
+            api_endpoint(),
+            ProviderHealthCheckRequest(probe=True, probe_prompt="health"),
+            api_transport=transport,
+        )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.status, "probe-failed")
+        self.assertIsNotNone(result.execution)
+        self.assertEqual(result.execution.status, "error")
+        self.assertEqual(result.reason, "api unavailable")
+
+    def test_aggregate_checks_preserve_endpoint_order(self):
+        endpoints = [
+            local_endpoint(),
+            local_endpoint(invocation=("missing-model",)),
+            local_endpoint(invocation=()),
+        ]
+
+        results = check_provider_health_many(
+            endpoints,
+            command_resolver=lambda command: "C:/tools/furyoku-local.exe"
+            if command == "furyoku-local"
+            else None,
+        )
+
+        self.assertEqual([result.model_id for result in results], ["local-ready", "local-ready", "local-ready"])
+        self.assertEqual([result.status for result in results], ["ready", "missing-command", "missing-invocation"])
+        self.assertEqual([result.ready for result in results], [True, False, False])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds provider readiness checks for registered local, CLI, and API endpoints. Includes command/invocation validation, optional probe execution, API transport readiness, aggregate health checks, and a CLI health command. Also records a scope guard in README so benchmark/CI work remains support infrastructure, not the primary FURYOKU lane. Verification: python -m py_compile furyoku/cli.py furyoku/provider_health.py furyoku/task_profiles.py furyoku/runtime.py furyoku/provider_adapters.py furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest discover -s tests; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #88.