### PR TITLE
Add CHARACTER composition profile loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Scope guard:
 Current routing core:
 
 - [`furyoku/model_router.py`](furyoku/model_router.py) defines the reusable model/task scoring contract and flexible CHARACTER composition selection.
+- [`furyoku/character_profiles.py`](furyoku/character_profiles.py) loads flexible JSON CHARACTER role compositions for Symbiote/Curator/Synth/Agent-style arrays.
 - [`furyoku/model_registry.py`](furyoku/model_registry.py) loads JSON endpoint registries into router-ready model definitions.
 - [`furyoku/task_profiles.py`](furyoku/task_profiles.py) loads reusable JSON task profiles into router-ready task requirements.
 - [`furyoku/provider_adapters.py`](furyoku/provider_adapters.py) executes selected local, CLI, and API endpoints through one observable result contract.
@@ -51,6 +52,9 @@ Current routing core:
 - [`furyoku/cli.py`](furyoku/cli.py) provides `select`, `run`, and `health` commands for registry-backed model routing, execution, and readiness checks.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
 - [`examples/task_profile.private-chat.json`](examples/task_profile.private-chat.json) shows reusable task profile configuration.
+- [`examples/character_profile.tertiary-symbiote.json`](examples/character_profile.tertiary-symbiote.json) shows a one-role tertiary Symbiote composition.
+- [`examples/character_profile.kira-array.json`](examples/character_profile.kira-array.json) shows a larger Kira-style one-primary/seven-secondary role array.
+- [`tests/test_character_profiles.py`](tests/test_character_profiles.py) verifies flexible CHARACTER profile loading and validation.
 - [`tests/test_model_router.py`](tests/test_model_router.py) verifies local-only selection, CLI/API routing, blocker reporting, flexible CHARACTER composition, and the three-role compatibility helper.
 - [`tests/test_model_registry.py`](tests/test_model_registry.py) verifies registry loading, validation, and routing from configuration.
 - [`tests/test_task_profiles.py`](tests/test_task_profiles.py) verifies task profile loading and validation.

--- a/examples/character_profile.kira-array.json
+++ b/examples/character_profile.kira-array.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "characterId": "kira",
+  "class": "Symbiote",
+  "rank": "Prototype",
+  "description": "Example larger CHARACTER composition with one primary role and seven secondary role agents.",
+  "roles": [
+    {
+      "roleId": "primary",
+      "primary": true,
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.primary",
+        "requiredCapabilities": {
+          "conversation": 0.9,
+          "instruction_following": 0.85,
+          "safety": 0.8
+        }
+      }
+    },
+    {
+      "roleId": "memory",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.memory",
+        "privacyRequirement": "prefer_local",
+        "requireJson": true,
+        "minContextTokens": 16000,
+        "requiredCapabilities": {
+          "retrieval": 0.85,
+          "summarization": 0.8
+        }
+      }
+    },
+    {
+      "roleId": "reasoning",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.reasoning",
+        "requiredCapabilities": {
+          "reasoning": 0.9,
+          "instruction_following": 0.85
+        }
+      }
+    },
+    {
+      "roleId": "coding",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.coding",
+        "requireTools": true,
+        "requiredCapabilities": {
+          "coding": 0.85,
+          "reasoning": 0.8
+        }
+      }
+    },
+    {
+      "roleId": "safety",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.safety",
+        "requiredCapabilities": {
+          "safety": 0.9,
+          "instruction_following": 0.8
+        }
+      }
+    },
+    {
+      "roleId": "planning",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.planning",
+        "requiredCapabilities": {
+          "reasoning": 0.85,
+          "summarization": 0.75
+        }
+      }
+    },
+    {
+      "roleId": "research",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.research",
+        "minContextTokens": 32000,
+        "requiredCapabilities": {
+          "retrieval": 0.8,
+          "summarization": 0.8
+        }
+      }
+    },
+    {
+      "roleId": "reflection",
+      "maxSubagents": 12,
+      "task": {
+        "taskId": "character.kira.reflection",
+        "requiredCapabilities": {
+          "reasoning": 0.8,
+          "conversation": 0.75
+        }
+      }
+    }
+  ]
+}

--- a/examples/character_profile.tertiary-symbiote.json
+++ b/examples/character_profile.tertiary-symbiote.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "characterId": "tertiary-symbiote",
+  "class": "Symbiote",
+  "rank": "Tertiary",
+  "description": "Fresh single-role CHARACTER composition where one primary role performs all work.",
+  "roles": [
+    {
+      "roleId": "primary",
+      "primary": true,
+      "maxSubagents": 0,
+      "task": {
+        "taskId": "character.tertiary-symbiote.primary",
+        "privacyRequirement": "prefer_local",
+        "requiredCapabilities": {
+          "conversation": 0.75,
+          "instruction_following": 0.75,
+          "reasoning": 0.65
+        }
+      }
+    }
+  ]
+}

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -14,6 +14,7 @@ from .model_router import (
     select_character_panel,
     select_model,
 )
+from .character_profiles import CharacterProfile, CharacterProfileError, load_character_profile, parse_character_profile
 from .model_registry import RegistryError, load_model_registry, parse_model_registry
 from .provider_adapters import (
     ApiProviderAdapter,
@@ -38,6 +39,8 @@ __all__ = [
     "ApiProviderAdapter",
     "CharacterCompositionSelection",
     "CharacterPanelSelection",
+    "CharacterProfile",
+    "CharacterProfileError",
     "CharacterRoleSpec",
     "ModelEndpoint",
     "ModelScore",
@@ -59,8 +62,10 @@ __all__ = [
     "check_provider_health",
     "check_provider_health_many",
     "load_model_registry",
+    "load_character_profile",
     "load_task_profile",
     "parse_model_registry",
+    "parse_character_profile",
     "parse_task_profile",
     "rank_models",
     "route_and_execute",

--- a/furyoku/character_profiles.py
+++ b/furyoku/character_profiles.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .model_router import CharacterRoleSpec
+from .task_profiles import parse_task_profile
+
+
+class CharacterProfileError(ValueError):
+    """Raised when a CHARACTER composition profile is malformed."""
+
+
+@dataclass(frozen=True)
+class CharacterProfile:
+    character_id: str
+    character_class: str
+    rank: str
+    role_specs: tuple[CharacterRoleSpec, ...]
+    description: str = ""
+
+    @property
+    def primary_role_id(self) -> str:
+        primary_roles = [role.role_id for role in self.role_specs if role.primary]
+        return primary_roles[0] if primary_roles else self.role_specs[0].role_id
+
+
+def load_character_profile(path: str | Path) -> CharacterProfile:
+    profile_path = Path(path)
+    with profile_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return parse_character_profile(payload, source=str(profile_path))
+
+
+def parse_character_profile(payload: Mapping[str, Any], *, source: str = "<memory>") -> CharacterProfile:
+    if not isinstance(payload, Mapping):
+        raise CharacterProfileError(f"{source}: CHARACTER profile must be a JSON object")
+    schema_version = payload.get("schemaVersion", payload.get("schema_version", 1))
+    if schema_version != 1:
+        raise CharacterProfileError(f"{source}: unsupported CHARACTER profile schemaVersion {schema_version!r}")
+
+    character_id = str(payload.get("characterId", payload.get("character_id", "")) or "").strip()
+    if not character_id:
+        raise CharacterProfileError(f"{source}: characterId is required")
+
+    roles_payload = payload.get("roles")
+    if not isinstance(roles_payload, list) or not roles_payload:
+        raise CharacterProfileError(f"{source}: roles must be a non-empty array")
+
+    role_specs = tuple(_parse_role(raw, source=source, index=index) for index, raw in enumerate(roles_payload))
+    _validate_roles(role_specs, source=source)
+    return CharacterProfile(
+        character_id=character_id,
+        character_class=str(payload.get("class", payload.get("characterClass", payload.get("character_class", ""))) or ""),
+        rank=str(payload.get("rank", "") or ""),
+        description=str(payload.get("description", "") or ""),
+        role_specs=role_specs,
+    )
+
+
+def _parse_role(raw: Mapping[str, Any], *, source: str, index: int) -> CharacterRoleSpec:
+    if not isinstance(raw, Mapping):
+        raise CharacterProfileError(f"{source}: roles[{index}] must be a JSON object")
+    role_id = str(raw.get("roleId", raw.get("role_id", "")) or "").strip()
+    if not role_id:
+        raise CharacterProfileError(f"{source}: roles[{index}].roleId is required")
+    task_payload = raw.get("task")
+    if not isinstance(task_payload, Mapping):
+        raise CharacterProfileError(f"{source}: roles[{index}].task must be a JSON object")
+    task = parse_task_profile({"schemaVersion": 1, **task_payload}, source=f"{source}:roles[{index}].task")
+    return CharacterRoleSpec(
+        role_id=role_id,
+        task=task,
+        primary=bool(raw.get("primary", False)),
+        max_subagents=int(raw.get("maxSubagents", raw.get("max_subagents", 0)) or 0),
+    )
+
+
+def _validate_roles(role_specs: tuple[CharacterRoleSpec, ...], *, source: str) -> None:
+    seen: set[str] = set()
+    primary_count = 0
+    for role in role_specs:
+        if role.role_id in seen:
+            raise CharacterProfileError(f"{source}: duplicate roleId '{role.role_id}'")
+        if role.max_subagents < 0:
+            raise CharacterProfileError(f"{source}: role '{role.role_id}' has negative maxSubagents")
+        if role.primary:
+            primary_count += 1
+        seen.add(role.role_id)
+    if primary_count > 1:
+        raise CharacterProfileError(f"{source}: only one role can be primary")

--- a/tests/test_character_profiles.py
+++ b/tests/test_character_profiles.py
@@ -1,0 +1,80 @@
+import unittest
+from pathlib import Path
+
+from furyoku import CharacterProfileError, load_character_profile, parse_character_profile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TERTIARY_PROFILE = ROOT / "examples" / "character_profile.tertiary-symbiote.json"
+KIRA_PROFILE = ROOT / "examples" / "character_profile.kira-array.json"
+
+
+class CharacterProfileTests(unittest.TestCase):
+    def test_load_tertiary_symbiote_single_role_profile(self):
+        profile = load_character_profile(TERTIARY_PROFILE)
+
+        self.assertEqual(profile.character_id, "tertiary-symbiote")
+        self.assertEqual(profile.character_class, "Symbiote")
+        self.assertEqual(profile.rank, "Tertiary")
+        self.assertEqual(profile.primary_role_id, "primary")
+        self.assertEqual(len(profile.role_specs), 1)
+        self.assertEqual(profile.role_specs[0].max_subagents, 0)
+
+    def test_load_kira_profile_with_one_primary_and_seven_secondary_roles(self):
+        profile = load_character_profile(KIRA_PROFILE)
+
+        self.assertEqual(profile.character_id, "kira")
+        self.assertEqual(profile.primary_role_id, "primary")
+        self.assertEqual(len(profile.role_specs), 8)
+        self.assertTrue(profile.role_specs[0].primary)
+        self.assertTrue(all(role.max_subagents == 12 for role in profile.role_specs))
+        self.assertEqual([role.role_id for role in profile.role_specs][1], "memory")
+
+    def test_duplicate_roles_are_rejected(self):
+        payload = {
+            "schemaVersion": 1,
+            "characterId": "broken",
+            "roles": [
+                {
+                    "roleId": "primary",
+                    "primary": True,
+                    "task": {"taskId": "a", "requiredCapabilities": {"conversation": 0.5}},
+                },
+                {
+                    "roleId": "primary",
+                    "task": {"taskId": "b", "requiredCapabilities": {"conversation": 0.5}},
+                },
+            ],
+        }
+
+        with self.assertRaises(CharacterProfileError) as error:
+            parse_character_profile(payload)
+
+        self.assertIn("duplicate roleId", str(error.exception))
+
+    def test_multiple_primary_roles_are_rejected(self):
+        payload = {
+            "schemaVersion": 1,
+            "characterId": "broken",
+            "roles": [
+                {
+                    "roleId": "a",
+                    "primary": True,
+                    "task": {"taskId": "a", "requiredCapabilities": {"conversation": 0.5}},
+                },
+                {
+                    "roleId": "b",
+                    "primary": True,
+                    "task": {"taskId": "b", "requiredCapabilities": {"conversation": 0.5}},
+                },
+            ],
+        }
+
+        with self.assertRaises(CharacterProfileError) as error:
+            parse_character_profile(payload)
+
+        self.assertIn("only one role", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds reusable JSON CHARACTER composition profiles for the flexible MOA/CHARACTER foundation. Includes a one-role tertiary Symbiote example, a Kira-style one-primary/seven-secondary role array with per-role subagent capacity, loader/validation APIs, exports, README references, and tests. Verification: python -m py_compile furyoku/character_profiles.py furyoku/cli.py furyoku/provider_health.py furyoku/task_profiles.py furyoku/runtime.py furyoku/provider_adapters.py furyoku/model_router.py furyoku/model_registry.py furyoku/__init__.py; python -m unittest discover -s tests; python benchmarks/openclaw-local-llm/test_benchmark_contract_report.py; powershell -ExecutionPolicy Bypass -File benchmarks/openclaw-local-llm/check_compare_truth_fresh.ps1; git diff --check. Closes #90.