### PR TITLE
Use feedback during decision execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#123](https://github.com/JKhyro/FURYOKU/issues/123)
+- Current active lane: [#125](https://github.com/JKhyro/FURYOKU/issues/125)
 - Current downstream CHARACTER/MOA lane: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: use persisted outcome feedback to adjust eligible model decisions.
+- Current follow-on focus: use persisted outcome feedback during decision-suite execution.
 
 ## Product Direction
 
@@ -82,6 +82,7 @@ python -m furyoku.cli decide --registry .\examples\model_registry.example.json -
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --output .\decision-report.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --feedback-log .\decision-outcomes.jsonl
 python -m furyoku.cli run --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --situation-id decision.private-chat --prompt "Hello"
+python -m furyoku.cli run --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --situation-id decision.private-chat --prompt "Hello" --feedback-log .\decision-outcomes.jsonl
 python -m furyoku.cli feedback --report .\decision-report.json --feedback-log .\decision-outcomes.jsonl --verdict success --score 0.9 --reason "accepted response"
 python -m furyoku.cli health --registry .\examples\model_registry.example.json
 python -m furyoku.cli character-select --registry .\examples\model_registry.example.json --character-profile .\examples\character_profile.kira-array.json

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -61,16 +61,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "run":
+        if args.feedback_log and not args.decision_suite:
+            parser.error("--feedback-log is only supported with --decision-suite")
         if args.decision_suite:
             if not args.situation_id:
                 parser.error("--situation-id is required when --decision-suite is provided")
             readiness = _readiness_from_args(args, models)
+            feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
             result = execute_decision_situation(
                 models,
                 load_decision_suite(args.decision_suite),
                 args.situation_id,
                 ProviderExecutionRequest(args.prompt, timeout_seconds=args.timeout_seconds),
                 readiness=readiness,
+                feedback=feedback,
             )
             _write_json(_decision_execution_result_to_dict(result, readiness=readiness), output_path=args.output)
             return 0 if result.ok else 2
@@ -169,6 +173,11 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--health-probe", action="store_true", help="Run lightweight provider probes with --check-health.")
     run_parser.add_argument("--health-probe-prompt", default="", help="Prompt text used when --health-probe is set.")
     run_parser.add_argument("--health-timeout-seconds", type=float, default=5.0, help="Health probe timeout in seconds.")
+    run_parser.add_argument(
+        "--feedback-log",
+        type=Path,
+        help="Optional JSONL outcome feedback log used to adjust decision-suite execution selection.",
+    )
     health_parser = subparsers.add_parser("health", help="Check provider endpoint readiness for a registry.")
     health_parser.add_argument("--registry", required=True, type=Path, help="Path to a FURYOKU model registry JSON file.")
     health_parser.add_argument("--probe", action="store_true", help="Run a lightweight probe instead of only checking configuration.")
@@ -408,6 +417,10 @@ def _decision_execution_result_to_dict(result: DecisionSituationExecutionResult,
         "decision": result.decision.to_dict(),
         "execution": _execution_to_dict(result.execution) if result.execution else None,
         "aggregate": result.report.aggregate.to_dict(),
+        "feedbackAdjustments": {
+            model_id: summary.to_dict()
+            for model_id, summary in result.report.feedback_adjustments.items()
+        },
     }
     if readiness is not None:
         payload["readiness"] = [_health_to_dict(result) for result in readiness]

--- a/furyoku/runtime.py
+++ b/furyoku/runtime.py
@@ -13,6 +13,7 @@ from .model_decisions import (
     evaluate_model_decisions,
 )
 from .model_router import ModelEndpoint, ModelScore, RouterError, TaskProfile, select_model
+from .outcome_feedback import FeedbackAdjustmentInput
 from .provider_adapters import (
     ProviderAdapter,
     ProviderExecutionRequest,
@@ -111,11 +112,12 @@ def execute_decision_situation(
     request: ProviderExecutionRequest | str,
     *,
     readiness: ReadinessEvidenceInput | None = None,
+    feedback: FeedbackAdjustmentInput | None = None,
     adapters: Mapping[str, ProviderAdapter] | None = None,
 ) -> DecisionSituationExecutionResult:
     """Run one calibrated decision situation using the same selection evidence as `decide`."""
 
-    report = evaluate_model_decisions(models, decision_input, readiness=readiness)
+    report = evaluate_model_decisions(models, decision_input, readiness=readiness, feedback=feedback)
     try:
         decision = report.situations[situation_id]
     except KeyError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,20 @@ def write_feedback_log(path: Path) -> None:
     path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
 
+def write_feedback_decision_suite(path: Path) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "suiteId": "feedback-suite",
+        "situations": [
+            {
+                "taskId": "feedback-chat",
+                "requiredCapabilities": {"conversation": 0.8},
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def write_decision_suite(path: Path) -> None:
     payload = {
         "schemaVersion": 1,
@@ -454,6 +468,39 @@ class CliTests(unittest.TestCase):
                     for blocker in payload["decision"]["blockers"]["local-echo"]
                 )
             )
+
+    def test_run_decision_suite_feedback_log_adjusts_executed_model(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            suite_path = Path(temp_dir) / "suite.json"
+            feedback_path = Path(temp_dir) / "feedback.jsonl"
+            write_executable_character_registry(registry_path)
+            write_feedback_decision_suite(suite_path)
+            write_feedback_log(feedback_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "run",
+                        "--registry",
+                        str(registry_path),
+                        "--decision-suite",
+                        str(suite_path),
+                        "--situation-id",
+                        "feedback-chat",
+                        "--prompt",
+                        "hello",
+                        "--feedback-log",
+                        str(feedback_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["selectedModel"]["modelId"], "local-echo")
+            self.assertEqual(payload["execution"]["responseText"].strip(), "echo:hello")
+            self.assertGreater(payload["feedbackAdjustments"]["local-echo"]["adjustment"], 0.0)
 
     def test_select_accepts_task_profile_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,6 +2,7 @@ import subprocess
 import unittest
 
 from furyoku import (
+    DecisionOutcomeRecord,
     ModelDecisionError,
     ModelEndpoint,
     ProviderExecutionRequest,
@@ -110,6 +111,52 @@ class RuntimeTests(unittest.TestCase):
         self.assertTrue(result.ok)
         self.assertEqual(result.model_id, "local-chat")
         self.assertEqual(result.decision.weight, 3.0)
+        self.assertEqual(result.execution.response_text, "local-chat:hello")
+
+    def test_execute_decision_situation_uses_feedback_informed_selection(self):
+        suite = parse_decision_suite(
+            {
+                "schemaVersion": 1,
+                "suiteId": "feedback-suite",
+                "situations": [
+                    {
+                        "taskId": "feedback-chat",
+                        "requiredCapabilities": {"conversation": 0.8},
+                    }
+                ],
+            }
+        )
+
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = execute_decision_situation(
+            [local_endpoint(), cli_endpoint()],
+            suite,
+            "feedback-chat",
+            "hello",
+            feedback=[
+                DecisionOutcomeRecord(
+                    record_id="feedback-1",
+                    report_path="decision-report.json",
+                    report_sha256="0" * 64,
+                    generated_at="2026-04-10T12:00:00+00:00",
+                    selected_model_id="local-chat",
+                    selected_provider="local",
+                    verdict="success",
+                    score=1.0,
+                )
+            ],
+            adapters={
+                "local": SubprocessProviderAdapter(runner),
+                "cli": SubprocessProviderAdapter(runner),
+            },
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.model_id, "local-chat")
+        self.assertIn("local-chat", result.report.feedback_adjustments)
+        self.assertTrue(any("outcome feedback adjustment" in reason for reason in result.selection.reasons))
         self.assertEqual(result.execution.response_text, "local-chat:hello")
 
     def test_execute_decision_situation_does_not_execute_threshold_blocked_task(self):


### PR DESCRIPTION
## Summary
- pass outcome feedback into `execute_decision_situation(...)`
- add `run --decision-suite --feedback-log` so execution uses feedback-informed model selection
- include feedback adjustment evidence in decision-suite execution reports
- update README active lane and CLI examples

## Verification
- `python -m unittest tests.test_runtime tests.test_cli tests.test_model_decisions tests.test_outcome_feedback` (50 OK)
- `python -m unittest discover -s tests` (94 OK)
- `python benchmarks\\openclaw-local-llm\\test_benchmark_contract_report.py` (9 OK)
- `benchmarks\\openclaw-local-llm\\check_compare_truth_fresh.ps1` (fresh)
- CLI smoke: temp executable registry selected and executed `local-echo` because feedback promoted it over `cli-echo`
- Pauli ai-engineer read-only review: no blockers

Closes #125