### PR TITLE
Use feedback for single-task routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#125](https://github.com/JKhyro/FURYOKU/issues/125)
+- Current active lane: [#127](https://github.com/JKhyro/FURYOKU/issues/127)
 - Current downstream CHARACTER/MOA lane: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: use persisted outcome feedback during decision-suite execution.
+- Current follow-on focus: use persisted outcome feedback during single-task selection and execution.
 
 ## Product Direction
 
@@ -77,12 +77,14 @@ CLI example:
 
 ```powershell
 python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json
+python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json --feedback-log .\decision-outcomes.jsonl
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --output .\decision-report.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --feedback-log .\decision-outcomes.jsonl
 python -m furyoku.cli run --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --situation-id decision.private-chat --prompt "Hello"
 python -m furyoku.cli run --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --situation-id decision.private-chat --prompt "Hello" --feedback-log .\decision-outcomes.jsonl
+python -m furyoku.cli run --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json --prompt "Hello" --feedback-log .\decision-outcomes.jsonl
 python -m furyoku.cli feedback --report .\decision-report.json --feedback-log .\decision-outcomes.jsonl --verdict success --score 0.9 --reason "accepted response"
 python -m furyoku.cli health --registry .\examples\model_registry.example.json
 python -m furyoku.cli character-select --registry .\examples\model_registry.example.json --character-profile .\examples\character_profile.kira-array.json

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -14,7 +14,7 @@ from .character_profiles import (
     select_character_profile_models,
 )
 from .model_registry import load_model_registry
-from .model_router import ModelScore, TaskProfile, select_model
+from .model_router import ModelScore, RouterError, TaskProfile, select_model
 from .model_decisions import ModelDecisionReport, evaluate_model_decisions, load_decision_suite
 from .outcome_feedback import (
     VALID_OUTCOME_VERDICTS,
@@ -56,13 +56,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "select":
         task = _task_from_args(args, parser)
-        selection = select_model(models, task)
-        _write_json(_score_to_dict(selection))
+        feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
+        selection, report = _select_with_optional_feedback(models, task, feedback)
+        _write_json(_single_selection_to_dict(selection, report=report))
         return 0
 
     if args.command == "run":
-        if args.feedback_log and not args.decision_suite:
-            parser.error("--feedback-log is only supported with --decision-suite")
         if args.decision_suite:
             if not args.situation_id:
                 parser.error("--situation-id is required when --decision-suite is provided")
@@ -80,10 +79,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0 if result.ok else 2
 
         task = _task_from_args(args, parser)
+        feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
         result = route_and_execute(
             models,
             task,
             ProviderExecutionRequest(args.prompt, timeout_seconds=args.timeout_seconds),
+            feedback=feedback,
         )
         _write_json(_routed_result_to_dict(result), output_path=args.output)
         return 0 if result.ok else 2
@@ -150,7 +151,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="FURYOKU multi-model router/runtime CLI.")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    _add_common_task_args(subparsers.add_parser("select", help="Select the best eligible model for a task."))
+    select_parser = subparsers.add_parser("select", help="Select the best eligible model for a task.")
+    _add_common_task_args(select_parser)
+    select_parser.add_argument(
+        "--feedback-log",
+        type=Path,
+        help="Optional JSONL outcome feedback log used to adjust eligible model rankings.",
+    )
     run_parser = subparsers.add_parser("run", help="Select and execute the best eligible model for a task.")
     _add_common_task_args(run_parser)
     run_parser.add_argument(
@@ -377,6 +384,21 @@ def _parse_capabilities(raw_values: Sequence[str]) -> dict[str, float]:
     return capabilities
 
 
+def _select_with_optional_feedback(models, task: TaskProfile, feedback):
+    if feedback is None:
+        return select_model(models, task), None
+    report = evaluate_model_decisions(models, [task], feedback=feedback)
+    selection = report.selected_for(task.task_id)
+    if selection is None:
+        decision = report.situations[task.task_id]
+        blocker_summary = "; ".join(
+            f"{model_id}: {', '.join(blockers)}"
+            for model_id, blockers in decision.blockers.items()
+        )
+        raise RouterError(f"No eligible model for task '{task.task_id}'. {blocker_summary}")
+    return selection, report
+
+
 def _readiness_from_args(args: argparse.Namespace, models):
     if not getattr(args, "check_health", False):
         return None
@@ -401,12 +423,22 @@ def _score_to_dict(selection: ModelScore) -> dict:
     }
 
 
+def _single_selection_to_dict(selection: ModelScore, *, report: ModelDecisionReport | None = None) -> dict:
+    payload = _score_to_dict(selection)
+    if report is not None:
+        payload["feedbackAdjustments"] = _feedback_adjustments_to_dict(report)
+    return payload
+
+
 def _routed_result_to_dict(result: RoutedExecutionResult) -> dict:
-    return {
+    payload = {
         "ok": result.ok,
         "selection": _score_to_dict(result.selection),
         "execution": _execution_to_dict(result.execution),
     }
+    if result.report is not None:
+        payload["feedbackAdjustments"] = _feedback_adjustments_to_dict(result.report)
+    return payload
 
 
 def _decision_execution_result_to_dict(result: DecisionSituationExecutionResult, *, readiness=None) -> dict:
@@ -417,10 +449,7 @@ def _decision_execution_result_to_dict(result: DecisionSituationExecutionResult,
         "decision": result.decision.to_dict(),
         "execution": _execution_to_dict(result.execution) if result.execution else None,
         "aggregate": result.report.aggregate.to_dict(),
-        "feedbackAdjustments": {
-            model_id: summary.to_dict()
-            for model_id, summary in result.report.feedback_adjustments.items()
-        },
+        "feedbackAdjustments": _feedback_adjustments_to_dict(result.report),
     }
     if readiness is not None:
         payload["readiness"] = [_health_to_dict(result) for result in readiness]
@@ -457,10 +486,7 @@ def _decision_report_to_dict(report: ModelDecisionReport, *, readiness=None) -> 
             for summary in report.summaries
         ],
         "aggregate": report.aggregate.to_dict(),
-        "feedbackAdjustments": {
-            model_id: summary.to_dict()
-            for model_id, summary in report.feedback_adjustments.items()
-        },
+        "feedbackAdjustments": _feedback_adjustments_to_dict(report),
     }
     if readiness is not None:
         payload["readiness"] = [_health_to_dict(result) for result in readiness]
@@ -494,6 +520,13 @@ def _execution_to_dict(execution: ProviderExecutionResult) -> dict:
 
 def _character_profile_selection_to_dict(selection: CharacterProfileSelection) -> dict:
     return build_character_orchestration_envelope(selection).to_dict()
+
+
+def _feedback_adjustments_to_dict(report: ModelDecisionReport) -> dict:
+    return {
+        model_id: summary.to_dict()
+        for model_id, summary in report.feedback_adjustments.items()
+    }
 
 
 def _health_to_dict(result: ProviderHealthCheckResult) -> dict:

--- a/furyoku/runtime.py
+++ b/furyoku/runtime.py
@@ -28,6 +28,7 @@ class RoutedExecutionResult:
 
     selection: ModelScore
     execution: ProviderExecutionResult
+    report: ModelDecisionReport | None = None
 
     @property
     def ok(self) -> bool:
@@ -96,13 +97,26 @@ def route_and_execute(
     task: TaskProfile,
     request: ProviderExecutionRequest | str,
     *,
+    feedback: FeedbackAdjustmentInput | None = None,
     adapters: Mapping[str, ProviderAdapter] | None = None,
 ) -> RoutedExecutionResult:
     """Select the best eligible model for a task, then execute it."""
 
-    selection = select_model(models, task)
+    report = None
+    if feedback is None:
+        selection = select_model(models, task)
+    else:
+        report = evaluate_model_decisions(models, [task], feedback=feedback)
+        selection = report.selected_for(task.task_id)
+        if selection is None:
+            decision = report.situations[task.task_id]
+            blocker_summary = "; ".join(
+                f"{model_id}: {', '.join(blockers)}"
+                for model_id, blockers in decision.blockers.items()
+            )
+            raise RouterError(f"No eligible model for task '{task.task_id}'. {blocker_summary}")
     execution = execute_selected_model(selection, request, adapters=adapters)
-    return RoutedExecutionResult(selection=selection, execution=execution)
+    return RoutedExecutionResult(selection=selection, execution=execution, report=report)
 
 
 def execute_decision_situation(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -525,6 +525,65 @@ class CliTests(unittest.TestCase):
             self.assertEqual(exit_code, 0)
             self.assertEqual(payload["modelId"], "local-echo")
 
+    def test_select_feedback_log_adjusts_single_task_ranking(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "task.json"
+            feedback_path = Path(temp_dir) / "feedback.jsonl"
+            write_registry(registry_path)
+            write_feedback_task_profile(task_path)
+            write_feedback_log(feedback_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "select",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                        "--feedback-log",
+                        str(feedback_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["modelId"], "local-echo")
+            self.assertGreater(payload["feedbackAdjustments"]["local-echo"]["adjustment"], 0.0)
+
+    def test_run_feedback_log_adjusts_single_task_executed_model(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "task.json"
+            feedback_path = Path(temp_dir) / "feedback.jsonl"
+            write_executable_character_registry(registry_path)
+            write_feedback_task_profile(task_path)
+            write_feedback_log(feedback_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "run",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                        "--prompt",
+                        "hello",
+                        "--feedback-log",
+                        str(feedback_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["selection"]["modelId"], "local-echo")
+            self.assertEqual(payload["execution"]["responseText"].strip(), "echo:hello")
+            self.assertGreater(payload["feedbackAdjustments"]["local-echo"]["adjustment"], 0.0)
+
     def test_health_reports_registry_provider_readiness(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             registry_path = Path(temp_dir) / "models.json"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -64,6 +64,38 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(result.execution.response_text, "local-chat:hello")
         self.assertGreater(result.selection.score, 0)
 
+    def test_route_and_execute_uses_feedback_informed_selection(self):
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = route_and_execute(
+            [local_endpoint(), cli_endpoint()],
+            TaskProfile(task_id="feedback-chat", required_capabilities={"conversation": 0.8}),
+            "hello",
+            feedback=[
+                DecisionOutcomeRecord(
+                    record_id="feedback-1",
+                    report_path="decision-report.json",
+                    report_sha256="0" * 64,
+                    generated_at="2026-04-10T12:00:00+00:00",
+                    selected_model_id="local-chat",
+                    selected_provider="local",
+                    verdict="success",
+                    score=1.0,
+                )
+            ],
+            adapters={
+                "local": SubprocessProviderAdapter(runner),
+                "cli": SubprocessProviderAdapter(runner),
+            },
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.model_id, "local-chat")
+        self.assertIsNotNone(result.report)
+        self.assertIn("local-chat", result.report.feedback_adjustments)
+        self.assertEqual(result.execution.response_text, "local-chat:hello")
+
     def test_route_and_execute_preserves_execution_failure_observability(self):
         def runner(invocation, prompt, timeout):
             return subprocess.CompletedProcess(invocation, 3, stdout="", stderr="bad runtime")


### PR DESCRIPTION
## Summary
- add feedback-informed routing to single-task `select`
- add feedback-informed routing to ordinary single-task `run`
- route single-task feedback through the same decision evaluator used by `decide`, preserving blocker and threshold behavior
- surface `feedbackAdjustments` in single-task select/run output when feedback is used

## Verification
- `python -m unittest tests.test_runtime tests.test_cli tests.test_model_decisions tests.test_outcome_feedback` (53 OK)
- `python -m unittest discover -s tests` (97 OK)
- `python benchmarks\\openclaw-local-llm\\test_benchmark_contract_report.py` (9 OK)
- `benchmarks\\openclaw-local-llm\\check_compare_truth_fresh.ps1` (fresh)
- CLI smoke: temp executable registry selected and executed `local-echo` through `select --feedback-log` and `run --feedback-log`
- Pauli ai-engineer read-only review: no blockers

Closes #127