### PR TITLE
Add configurable feedback policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Current routing core:
 - [`furyoku/provider_health.py`](furyoku/provider_health.py) checks registered endpoint readiness before routing work to a provider.
 - [`furyoku/outcome_feedback.py`](furyoku/outcome_feedback.py) records operator or automated feedback linked to persisted decision/execution reports.
 - Outcome feedback records can be aggregated into bounded per-model score adjustments for future decision reports.
+- [`examples/feedback_policy.example.json`](examples/feedback_policy.example.json) shows the configurable feedback adjustment policy contract for tuning max adjustment, verdict weights, default outcome scores, and optional recency decay.
 - [`furyoku/runtime.py`](furyoku/runtime.py) combines task-based routing with provider execution and returns selection evidence plus execution output.
 - [`furyoku/cli.py`](furyoku/cli.py) provides `select`, `decide`, `run`, `health`, `character-select`, and `character-run` commands for registry-backed model routing, multi-situation decisions, execution, readiness checks, CHARACTER role selection, and selected role execution.
 - [`examples/model_registry.example.json`](examples/model_registry.example.json) shows local, CLI, and API endpoint configuration.
@@ -78,13 +79,16 @@ CLI example:
 ```powershell
 python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json
 python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json --feedback-log .\decision-outcomes.jsonl
+python -m furyoku.cli select --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json --feedback-log .\decision-outcomes.jsonl --feedback-policy .\examples\feedback_policy.example.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --output .\decision-report.json
 python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --feedback-log .\decision-outcomes.jsonl
+python -m furyoku.cli decide --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --feedback-log .\decision-outcomes.jsonl --feedback-policy .\examples\feedback_policy.example.json
 python -m furyoku.cli run --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --situation-id decision.private-chat --prompt "Hello"
 python -m furyoku.cli run --registry .\examples\model_registry.example.json --decision-suite .\examples\decision_suite.primary-routing.json --situation-id decision.private-chat --prompt "Hello" --feedback-log .\decision-outcomes.jsonl
 python -m furyoku.cli run --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json --prompt "Hello" --feedback-log .\decision-outcomes.jsonl
+python -m furyoku.cli run --registry .\examples\model_registry.example.json --task-profile .\examples\task_profile.private-chat.json --prompt "Hello" --feedback-log .\decision-outcomes.jsonl --feedback-policy .\examples\feedback_policy.example.json
 python -m furyoku.cli feedback --report .\decision-report.json --feedback-log .\decision-outcomes.jsonl --verdict success --score 0.9 --reason "accepted response"
 python -m furyoku.cli health --registry .\examples\model_registry.example.json
 python -m furyoku.cli character-select --registry .\examples\model_registry.example.json --character-profile .\examples\character_profile.kira-array.json

--- a/examples/feedback_policy.example.json
+++ b/examples/feedback_policy.example.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "maxAdjustment": 12.0,
+  "successBase": 2.0,
+  "successScoreMultiplier": 8.0,
+  "failurePenalty": -10.0,
+  "qualityConcernPenalty": -7.0,
+  "latencyConcernPenalty": -4.0,
+  "costConcernPenalty": -4.0,
+  "manualOverridePenalty": -8.0,
+  "manualOverrideTargetBase": 6.0,
+  "manualOverrideTargetScoreMultiplier": 4.0,
+  "defaultSuccessScore": 1.0,
+  "defaultFailureScore": 0.0,
+  "defaultConcernScore": 0.35,
+  "defaultManualOverrideScore": 0.25,
+  "defaultOverrideTargetScore": 0.9,
+  "recencyHalfLifeDays": null
+}

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -62,6 +62,8 @@ from .provider_health import (
 from .outcome_feedback import (
     DecisionOutcomeRecord,
     FeedbackAdjustmentInput,
+    FeedbackAdjustmentPolicy,
+    FeedbackAdjustmentPolicyInput,
     ModelOutcomeFeedbackSummary,
     OutcomeFeedbackError,
     VALID_OUTCOME_VERDICTS,
@@ -69,6 +71,8 @@ from .outcome_feedback import (
     build_model_feedback_summaries,
     create_decision_outcome_record,
     load_decision_outcomes,
+    load_feedback_adjustment_policy,
+    parse_feedback_adjustment_policy,
 )
 from .runtime import (
     CharacterRoleExecutionResult,
@@ -96,6 +100,8 @@ __all__ = [
     "DecisionSituationExecutionResult",
     "DecisionOutcomeRecord",
     "FeedbackAdjustmentInput",
+    "FeedbackAdjustmentPolicy",
+    "FeedbackAdjustmentPolicyInput",
     "ModelCoverage",
     "ModelDecisionAggregate",
     "ModelDecisionError",
@@ -138,7 +144,9 @@ __all__ = [
     "load_character_profile",
     "load_decision_suite",
     "load_decision_outcomes",
+    "load_feedback_adjustment_policy",
     "load_task_profile",
+    "parse_feedback_adjustment_policy",
     "parse_model_registry",
     "parse_character_profile",
     "parse_decision_suite",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -20,6 +20,7 @@ from .outcome_feedback import (
     VALID_OUTCOME_VERDICTS,
     append_decision_outcome,
     create_decision_outcome_record,
+    load_feedback_adjustment_policy,
     load_decision_outcomes,
 )
 from .provider_health import ProviderHealthCheckRequest, ProviderHealthCheckResult, check_provider_health_many
@@ -56,8 +57,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "select":
         task = _task_from_args(args, parser)
-        feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
-        selection, report = _select_with_optional_feedback(models, task, feedback)
+        feedback, feedback_policy = _feedback_from_args(args, parser)
+        selection, report = _select_with_optional_feedback(models, task, feedback, feedback_policy=feedback_policy)
         _write_json(_single_selection_to_dict(selection, report=report))
         return 0
 
@@ -66,7 +67,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             if not args.situation_id:
                 parser.error("--situation-id is required when --decision-suite is provided")
             readiness = _readiness_from_args(args, models)
-            feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
+            feedback, feedback_policy = _feedback_from_args(args, parser)
             result = execute_decision_situation(
                 models,
                 load_decision_suite(args.decision_suite),
@@ -74,17 +75,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 ProviderExecutionRequest(args.prompt, timeout_seconds=args.timeout_seconds),
                 readiness=readiness,
                 feedback=feedback,
+                feedback_policy=feedback_policy,
             )
             _write_json(_decision_execution_result_to_dict(result, readiness=readiness), output_path=args.output)
             return 0 if result.ok else 2
 
         task = _task_from_args(args, parser)
-        feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
+        feedback, feedback_policy = _feedback_from_args(args, parser)
         result = route_and_execute(
             models,
             task,
             ProviderExecutionRequest(args.prompt, timeout_seconds=args.timeout_seconds),
             feedback=feedback,
+            feedback_policy=feedback_policy,
         )
         _write_json(_routed_result_to_dict(result), output_path=args.output)
         return 0 if result.ok else 2
@@ -108,12 +111,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             load_task_profile(path) for path in args.task_profile
         )
         readiness = _readiness_from_args(args, models)
-        feedback = load_decision_outcomes(args.feedback_log) if args.feedback_log else None
+        feedback, feedback_policy = _feedback_from_args(args, parser)
         report = evaluate_model_decisions(
             models,
             decision_input or None,
             readiness=readiness,
             feedback=feedback,
+            feedback_policy=feedback_policy,
         )
         _write_json(_decision_report_to_dict(report, readiness=readiness), output_path=args.output)
         return 0 if not report.blocked_tasks else 2
@@ -158,6 +162,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional JSONL outcome feedback log used to adjust eligible model rankings.",
     )
+    _add_feedback_policy_arg(select_parser)
     run_parser = subparsers.add_parser("run", help="Select and execute the best eligible model for a task.")
     _add_common_task_args(run_parser)
     run_parser.add_argument(
@@ -185,6 +190,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional JSONL outcome feedback log used to adjust decision-suite execution selection.",
     )
+    _add_feedback_policy_arg(run_parser)
     health_parser = subparsers.add_parser("health", help="Check provider endpoint readiness for a registry.")
     health_parser.add_argument("--registry", required=True, type=Path, help="Path to a FURYOKU model registry JSON file.")
     health_parser.add_argument("--probe", action="store_true", help="Run a lightweight probe instead of only checking configuration.")
@@ -220,6 +226,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional JSONL outcome feedback log used to adjust eligible model rankings.",
     )
+    _add_feedback_policy_arg(decide_parser)
     decide_parser.add_argument("--output", type=Path, help="Optional path to persist the JSON decision report.")
     feedback_parser = subparsers.add_parser(
         "feedback",
@@ -292,6 +299,14 @@ def _add_health_decision_args(parser: argparse.ArgumentParser, help_text: str) -
     parser.add_argument("--health-probe", action="store_true", help="Run lightweight provider probes with --check-health.")
     parser.add_argument("--health-probe-prompt", default="", help="Prompt text used when --health-probe is set.")
     parser.add_argument("--health-timeout-seconds", type=float, default=5.0, help="Health probe timeout in seconds.")
+
+
+def _add_feedback_policy_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--feedback-policy",
+        type=Path,
+        help="Optional JSON feedback adjustment policy used with --feedback-log.",
+    )
 
 
 def _add_common_task_args(parser: argparse.ArgumentParser) -> None:
@@ -384,10 +399,10 @@ def _parse_capabilities(raw_values: Sequence[str]) -> dict[str, float]:
     return capabilities
 
 
-def _select_with_optional_feedback(models, task: TaskProfile, feedback):
+def _select_with_optional_feedback(models, task: TaskProfile, feedback, *, feedback_policy=None):
     if feedback is None:
         return select_model(models, task), None
-    report = evaluate_model_decisions(models, [task], feedback=feedback)
+    report = evaluate_model_decisions(models, [task], feedback=feedback, feedback_policy=feedback_policy)
     selection = report.selected_for(task.task_id)
     if selection is None:
         decision = report.situations[task.task_id]
@@ -397,6 +412,19 @@ def _select_with_optional_feedback(models, task: TaskProfile, feedback):
         )
         raise RouterError(f"No eligible model for task '{task.task_id}'. {blocker_summary}")
     return selection, report
+
+
+def _feedback_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser):
+    feedback_log = getattr(args, "feedback_log", None)
+    feedback_policy_path = getattr(args, "feedback_policy", None)
+    if not feedback_log:
+        if feedback_policy_path:
+            parser.error("--feedback-policy requires --feedback-log")
+        return None, None
+    return (
+        load_decision_outcomes(feedback_log),
+        load_feedback_adjustment_policy(feedback_policy_path) if feedback_policy_path else None,
+    )
 
 
 def _readiness_from_args(args: argparse.Namespace, models):

--- a/furyoku/model_decisions.py
+++ b/furyoku/model_decisions.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Mapping
 from .model_router import ModelEndpoint, ModelScore, TaskProfile, rank_models
 from .outcome_feedback import (
     FeedbackAdjustmentInput,
+    FeedbackAdjustmentPolicyInput,
     ModelOutcomeFeedbackSummary,
     build_model_feedback_summaries,
 )
@@ -496,6 +497,7 @@ def evaluate_model_decisions(
     *,
     readiness: ReadinessEvidenceInput | None = None,
     feedback: FeedbackAdjustmentInput | None = None,
+    feedback_policy: FeedbackAdjustmentPolicyInput | None = None,
     situation_weights: Mapping[str, float] | None = None,
     minimum_scores: Mapping[str, float] | None = None,
 ) -> ModelDecisionReport:
@@ -516,7 +518,7 @@ def evaluate_model_decisions(
     _validate_inputs(model_list, task_list)
     readiness_by_model = _normalize_readiness_evidence(readiness)
     _validate_readiness_evidence(readiness_by_model, model_list)
-    feedback_by_model = _feedback_for_models(feedback, model_list)
+    feedback_by_model = _feedback_for_models(feedback, model_list, feedback_policy=feedback_policy)
 
     situation_decisions: dict[str, SituationDecision] = {}
     for task in task_list:
@@ -662,13 +664,15 @@ def _validate_readiness_evidence(
 def _feedback_for_models(
     feedback: FeedbackAdjustmentInput | None,
     models: list[ModelEndpoint],
+    *,
+    feedback_policy: FeedbackAdjustmentPolicyInput | None,
 ) -> dict[str, ModelOutcomeFeedbackSummary]:
     if feedback is None:
         return {}
     known_model_ids = {model.model_id for model in models}
     return {
         model_id: summary
-        for model_id, summary in build_model_feedback_summaries(feedback).items()
+        for model_id, summary in build_model_feedback_summaries(feedback, policy=feedback_policy).items()
         if model_id in known_model_ids
     }
 

--- a/furyoku/outcome_feedback.py
+++ b/furyoku/outcome_feedback.py
@@ -203,7 +203,7 @@ class ModelOutcomeFeedbackSummary:
     manual_override_count: int
     average_score: float | None
     adjustment: float
-    weighted_record_count: float
+    weighted_record_count: float = 0.0
     rationale: tuple[str, ...] = ()
 
     def to_dict(self) -> dict:

--- a/furyoku/outcome_feedback.py
+++ b/furyoku/outcome_feedback.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -96,6 +96,102 @@ FeedbackAdjustmentInput = Iterable[DecisionOutcomeRecord | Mapping[str, Any]]
 
 
 @dataclass(frozen=True)
+class FeedbackAdjustmentPolicy:
+    """Configurable scoring policy for turning outcome records into routing evidence."""
+
+    max_adjustment: float = 12.0
+    success_base: float = 2.0
+    success_score_multiplier: float = 8.0
+    failure_penalty: float = -10.0
+    quality_concern_penalty: float = -7.0
+    latency_concern_penalty: float = -4.0
+    cost_concern_penalty: float = -4.0
+    manual_override_penalty: float = -8.0
+    manual_override_target_base: float = 6.0
+    manual_override_target_score_multiplier: float = 4.0
+    default_success_score: float = 1.0
+    default_failure_score: float = 0.0
+    default_concern_score: float = 0.35
+    default_manual_override_score: float = 0.25
+    default_override_target_score: float = 0.9
+    recency_half_life_days: float | None = None
+
+    def __post_init__(self) -> None:
+        _validate_non_negative_float(self.max_adjustment, "maxAdjustment", source="<feedback-policy>")
+        if self.recency_half_life_days is not None:
+            _validate_positive_float(
+                self.recency_half_life_days,
+                "recencyHalfLifeDays",
+                source="<feedback-policy>",
+            )
+        for field_name in (
+            "default_success_score",
+            "default_failure_score",
+            "default_concern_score",
+            "default_manual_override_score",
+            "default_override_target_score",
+        ):
+            _validate_score_range(getattr(self, field_name), _camel_name(field_name), source="<feedback-policy>")
+
+    def to_dict(self) -> dict:
+        return {
+            "schemaVersion": 1,
+            "maxAdjustment": self.max_adjustment,
+            "successBase": self.success_base,
+            "successScoreMultiplier": self.success_score_multiplier,
+            "failurePenalty": self.failure_penalty,
+            "qualityConcernPenalty": self.quality_concern_penalty,
+            "latencyConcernPenalty": self.latency_concern_penalty,
+            "costConcernPenalty": self.cost_concern_penalty,
+            "manualOverridePenalty": self.manual_override_penalty,
+            "manualOverrideTargetBase": self.manual_override_target_base,
+            "manualOverrideTargetScoreMultiplier": self.manual_override_target_score_multiplier,
+            "defaultSuccessScore": self.default_success_score,
+            "defaultFailureScore": self.default_failure_score,
+            "defaultConcernScore": self.default_concern_score,
+            "defaultManualOverrideScore": self.default_manual_override_score,
+            "defaultOverrideTargetScore": self.default_override_target_score,
+            "recencyHalfLifeDays": self.recency_half_life_days,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any], *, source: str = "<memory>") -> "FeedbackAdjustmentPolicy":
+        if not isinstance(payload, Mapping):
+            raise OutcomeFeedbackError(f"{source}: feedback adjustment policy must be an object")
+        schema_version = payload.get("schemaVersion", payload.get("schema_version", 1))
+        if schema_version != 1:
+            raise OutcomeFeedbackError(f"{source}: unsupported feedback policy schemaVersion {schema_version!r}")
+        defaults = cls()
+        return cls(
+            max_adjustment=_policy_float(payload, "maxAdjustment", "max_adjustment", default=defaults.max_adjustment, source=source),
+            success_base=_policy_float(payload, "successBase", "success_base", default=defaults.success_base, source=source),
+            success_score_multiplier=_policy_float(payload, "successScoreMultiplier", "success_score_multiplier", default=defaults.success_score_multiplier, source=source),
+            failure_penalty=_policy_float(payload, "failurePenalty", "failure_penalty", default=defaults.failure_penalty, source=source),
+            quality_concern_penalty=_policy_float(payload, "qualityConcernPenalty", "quality_concern_penalty", default=defaults.quality_concern_penalty, source=source),
+            latency_concern_penalty=_policy_float(payload, "latencyConcernPenalty", "latency_concern_penalty", default=defaults.latency_concern_penalty, source=source),
+            cost_concern_penalty=_policy_float(payload, "costConcernPenalty", "cost_concern_penalty", default=defaults.cost_concern_penalty, source=source),
+            manual_override_penalty=_policy_float(payload, "manualOverridePenalty", "manual_override_penalty", default=defaults.manual_override_penalty, source=source),
+            manual_override_target_base=_policy_float(payload, "manualOverrideTargetBase", "manual_override_target_base", default=defaults.manual_override_target_base, source=source),
+            manual_override_target_score_multiplier=_policy_float(payload, "manualOverrideTargetScoreMultiplier", "manual_override_target_score_multiplier", default=defaults.manual_override_target_score_multiplier, source=source),
+            default_success_score=_policy_float(payload, "defaultSuccessScore", "default_success_score", default=defaults.default_success_score, source=source),
+            default_failure_score=_policy_float(payload, "defaultFailureScore", "default_failure_score", default=defaults.default_failure_score, source=source),
+            default_concern_score=_policy_float(payload, "defaultConcernScore", "default_concern_score", default=defaults.default_concern_score, source=source),
+            default_manual_override_score=_policy_float(payload, "defaultManualOverrideScore", "default_manual_override_score", default=defaults.default_manual_override_score, source=source),
+            default_override_target_score=_policy_float(payload, "defaultOverrideTargetScore", "default_override_target_score", default=defaults.default_override_target_score, source=source),
+            recency_half_life_days=_policy_optional_positive_float(
+                payload,
+                "recencyHalfLifeDays",
+                "recency_half_life_days",
+                default=defaults.recency_half_life_days,
+                source=source,
+            ),
+        )
+
+
+FeedbackAdjustmentPolicyInput = FeedbackAdjustmentPolicy | Mapping[str, Any]
+
+
+@dataclass(frozen=True)
 class ModelOutcomeFeedbackSummary:
     """Bounded per-model outcome evidence used to adjust eligible rankings."""
 
@@ -107,6 +203,7 @@ class ModelOutcomeFeedbackSummary:
     manual_override_count: int
     average_score: float | None
     adjustment: float
+    weighted_record_count: float
     rationale: tuple[str, ...] = ()
 
     def to_dict(self) -> dict:
@@ -119,6 +216,7 @@ class ModelOutcomeFeedbackSummary:
             "manualOverrideCount": self.manual_override_count,
             "averageScore": self.average_score,
             "adjustment": self.adjustment,
+            "weightedRecordCount": self.weighted_record_count,
             "rationale": list(self.rationale),
         }
 
@@ -128,6 +226,7 @@ class _FeedbackStats:
     model_id: str
     contributions: list[float] = field(default_factory=list)
     scores: list[float] = field(default_factory=list)
+    weights: list[float] = field(default_factory=list)
     success_count: int = 0
     concern_count: int = 0
     failure_count: int = 0
@@ -182,15 +281,20 @@ def create_decision_outcome_record(
 def build_model_feedback_summaries(
     records: FeedbackAdjustmentInput,
     *,
-    max_adjustment: float = 12.0,
+    max_adjustment: float | None = None,
+    policy: FeedbackAdjustmentPolicyInput | None = None,
+    as_of: datetime | str | None = None,
 ) -> dict[str, ModelOutcomeFeedbackSummary]:
     """Aggregate outcome records into bounded per-model score adjustments."""
 
+    resolved_policy = _resolve_feedback_policy(policy, max_adjustment=max_adjustment)
+    resolved_as_of = _parse_as_of(as_of)
     stats_by_model: dict[str, _FeedbackStats] = {}
     for index, raw_record in enumerate(records, start=1):
         record = _normalize_feedback_record(raw_record, source=f"<feedback:{index}>")
+        weight = _recency_weight(record, resolved_policy, as_of=resolved_as_of)
         if record.selected_model_id:
-            _add_selected_feedback(stats_by_model, record)
+            _add_selected_feedback(stats_by_model, record, resolved_policy, weight=weight)
         if (
             record.verdict == "manual_override"
             and record.override_model_id
@@ -199,17 +303,29 @@ def build_model_feedback_summaries(
             _add_feedback_contribution(
                 stats_by_model,
                 record.override_model_id,
-                contribution=_manual_override_target_contribution(record.score),
-                score=record.score if record.score is not None else 0.9,
+                contribution=_manual_override_target_contribution(record.score, resolved_policy),
+                score=record.score if record.score is not None else resolved_policy.default_override_target_score,
                 verdict=record.verdict,
                 override_target=True,
+                weight=weight,
             )
 
     return {
-        model_id: _summarize_feedback_stats(stats, max_adjustment=max_adjustment)
+        model_id: _summarize_feedback_stats(stats, policy=resolved_policy)
         for model_id, stats in sorted(stats_by_model.items())
         if stats.record_count
     }
+
+
+def load_feedback_adjustment_policy(path: str | Path) -> FeedbackAdjustmentPolicy:
+    policy_path = Path(path)
+    with policy_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return parse_feedback_adjustment_policy(payload, source=str(policy_path))
+
+
+def parse_feedback_adjustment_policy(payload: Mapping[str, Any], *, source: str = "<memory>") -> FeedbackAdjustmentPolicy:
+    return FeedbackAdjustmentPolicy.from_dict(payload, source=source)
 
 
 def append_decision_outcome(
@@ -256,14 +372,18 @@ def _normalize_feedback_record(
 def _add_selected_feedback(
     stats_by_model: dict[str, _FeedbackStats],
     record: DecisionOutcomeRecord,
+    policy: FeedbackAdjustmentPolicy,
+    *,
+    weight: float,
 ) -> None:
     _add_feedback_contribution(
         stats_by_model,
         record.selected_model_id,
-        contribution=_selected_model_contribution(record),
-        score=_score_for_record(record),
+        contribution=_selected_model_contribution(record, policy),
+        score=_score_for_record(record, policy),
         verdict=record.verdict,
         override_target=False,
+        weight=weight,
     )
 
 
@@ -275,10 +395,12 @@ def _add_feedback_contribution(
     score: float,
     verdict: str,
     override_target: bool,
+    weight: float,
 ) -> None:
     stats = stats_by_model.setdefault(model_id, _FeedbackStats(model_id=model_id))
     stats.contributions.append(contribution)
     stats.scores.append(score)
+    stats.weights.append(weight)
     if verdict == "success":
         stats.success_count += 1
     elif verdict == "failure":
@@ -291,33 +413,38 @@ def _add_feedback_contribution(
             stats.success_count += 1
 
 
-def _selected_model_contribution(record: DecisionOutcomeRecord) -> float:
+def _selected_model_contribution(record: DecisionOutcomeRecord, policy: FeedbackAdjustmentPolicy) -> float:
     if record.verdict == "success":
-        return 2.0 + (_score_for_record(record) * 8.0)
+        return policy.success_base + (_score_for_record(record, policy) * policy.success_score_multiplier)
     if record.verdict == "failure":
-        return -10.0
+        return policy.failure_penalty
     if record.verdict == "quality_concern":
-        return -7.0
-    if record.verdict in ("latency_concern", "cost_concern"):
-        return -4.0
+        return policy.quality_concern_penalty
+    if record.verdict == "latency_concern":
+        return policy.latency_concern_penalty
+    if record.verdict == "cost_concern":
+        return policy.cost_concern_penalty
     if record.verdict == "manual_override":
-        return -8.0
+        return policy.manual_override_penalty
     return 0.0
 
 
-def _manual_override_target_contribution(score: float | None) -> float:
-    return 6.0 + (_normalize_outcome_score(score, default=0.9) * 4.0)
+def _manual_override_target_contribution(score: float | None, policy: FeedbackAdjustmentPolicy) -> float:
+    return policy.manual_override_target_base + (
+        _normalize_outcome_score(score, default=policy.default_override_target_score)
+        * policy.manual_override_target_score_multiplier
+    )
 
 
-def _score_for_record(record: DecisionOutcomeRecord) -> float:
+def _score_for_record(record: DecisionOutcomeRecord, policy: FeedbackAdjustmentPolicy) -> float:
     if record.verdict == "success":
-        return _normalize_outcome_score(record.score, default=1.0)
+        return _normalize_outcome_score(record.score, default=policy.default_success_score)
     if record.verdict == "failure":
-        return _normalize_outcome_score(record.score, default=0.0)
+        return _normalize_outcome_score(record.score, default=policy.default_failure_score)
     if record.verdict in ("latency_concern", "quality_concern", "cost_concern"):
-        return _normalize_outcome_score(record.score, default=0.35)
+        return _normalize_outcome_score(record.score, default=policy.default_concern_score)
     if record.verdict == "manual_override":
-        return _normalize_outcome_score(record.score, default=0.25)
+        return _normalize_outcome_score(record.score, default=policy.default_manual_override_score)
     return _normalize_outcome_score(record.score, default=0.5)
 
 
@@ -328,15 +455,30 @@ def _normalize_outcome_score(score: float | None, *, default: float) -> float:
 def _summarize_feedback_stats(
     stats: _FeedbackStats,
     *,
-    max_adjustment: float,
+    policy: FeedbackAdjustmentPolicy,
 ) -> ModelOutcomeFeedbackSummary:
-    raw_adjustment = sum(stats.contributions) / len(stats.contributions)
-    adjustment = round(max(-max_adjustment, min(max_adjustment, raw_adjustment)), 4)
-    average_score = round(sum(stats.scores) / len(stats.scores), 4) if stats.scores else None
+    weighted_count = sum(stats.weights) if stats.weights else float(len(stats.contributions))
+    if weighted_count <= 0.0:
+        raw_adjustment = 0.0
+        average_score = None
+    else:
+        raw_adjustment = sum(
+            contribution * weight
+            for contribution, weight in zip(stats.contributions, stats.weights)
+        ) / weighted_count
+        average_score = round(
+            sum(score * weight for score, weight in zip(stats.scores, stats.weights)) / weighted_count,
+            4,
+        ) if stats.scores else None
+    adjustment = round(max(-policy.max_adjustment, min(policy.max_adjustment, raw_adjustment)), 4)
     rationale = [
         f"{stats.record_count} outcome feedback records",
         f"bounded feedback adjustment {adjustment:+.2f}",
     ]
+    if policy.recency_half_life_days is not None:
+        rationale.append(
+            f"recency half-life {policy.recency_half_life_days:.2f} days; weighted records {weighted_count:.2f}"
+        )
     if average_score is not None:
         rationale.append(f"average outcome score {average_score:.2f}")
     if stats.success_count:
@@ -356,8 +498,138 @@ def _summarize_feedback_stats(
         manual_override_count=stats.manual_override_count,
         average_score=average_score,
         adjustment=adjustment,
+        weighted_record_count=round(weighted_count, 4),
         rationale=tuple(rationale),
     )
+
+
+def _resolve_feedback_policy(
+    policy: FeedbackAdjustmentPolicyInput | None,
+    *,
+    max_adjustment: float | None,
+) -> FeedbackAdjustmentPolicy:
+    if policy is None:
+        resolved = DEFAULT_FEEDBACK_ADJUSTMENT_POLICY
+    elif isinstance(policy, FeedbackAdjustmentPolicy):
+        resolved = policy
+    elif isinstance(policy, Mapping):
+        resolved = parse_feedback_adjustment_policy(policy, source="<feedback-policy>")
+    else:
+        raise OutcomeFeedbackError(f"Unsupported feedback policy type: {type(policy).__name__}")
+
+    if max_adjustment is None:
+        return resolved
+    return replace(
+        resolved,
+        max_adjustment=_validate_non_negative_float(
+            max_adjustment,
+            "maxAdjustment",
+            source="<feedback-policy>",
+        ),
+    )
+
+
+def _parse_as_of(as_of: datetime | str | None) -> datetime | None:
+    if as_of is None:
+        return None
+    if isinstance(as_of, datetime):
+        return _ensure_aware_utc(as_of)
+    if isinstance(as_of, str):
+        return _parse_feedback_datetime(as_of, source="<feedback-policy>:asOf")
+    raise OutcomeFeedbackError(f"<feedback-policy>: as_of must be a datetime or ISO timestamp")
+
+
+def _recency_weight(
+    record: DecisionOutcomeRecord,
+    policy: FeedbackAdjustmentPolicy,
+    *,
+    as_of: datetime | None,
+) -> float:
+    if policy.recency_half_life_days is None:
+        return 1.0
+
+    record_time = _parse_feedback_datetime(record.generated_at, source=f"<feedback:{record.record_id}>")
+    comparison_time = as_of or datetime.now(timezone.utc)
+    age_seconds = max(0.0, (_ensure_aware_utc(comparison_time) - record_time).total_seconds())
+    age_days = age_seconds / 86400.0
+    return 0.5 ** (age_days / policy.recency_half_life_days)
+
+
+def _parse_feedback_datetime(value: str, *, source: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise OutcomeFeedbackError(f"{source}: generatedAt must be an ISO timestamp") from exc
+    return _ensure_aware_utc(parsed)
+
+
+def _ensure_aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _policy_float(
+    payload: Mapping[str, Any],
+    *keys: str,
+    default: float,
+    source: str,
+) -> float:
+    for key in keys:
+        if key in payload:
+            return _parse_float(payload[key], field_name=key, source=source)
+    return float(default)
+
+
+def _policy_optional_positive_float(
+    payload: Mapping[str, Any],
+    *keys: str,
+    default: float | None,
+    source: str,
+) -> float | None:
+    for key in keys:
+        if key in payload:
+            value = payload[key]
+            if value in (None, ""):
+                return None
+            return _validate_positive_float(value, key, source=source)
+    return default
+
+
+def _parse_float(value: Any, *, field_name: str, source: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise OutcomeFeedbackError(f"{source}: {field_name} must be numeric") from exc
+
+
+def _validate_non_negative_float(value: float, field_name: str, *, source: str) -> float:
+    parsed = _parse_float(value, field_name=field_name, source=source)
+    if parsed < 0.0:
+        raise OutcomeFeedbackError(f"{source}: {field_name} must be 0 or greater")
+    return parsed
+
+
+def _validate_positive_float(value: float, field_name: str, *, source: str) -> float:
+    parsed = _parse_float(value, field_name=field_name, source=source)
+    if parsed <= 0.0:
+        raise OutcomeFeedbackError(f"{source}: {field_name} must be greater than 0")
+    return parsed
+
+
+def _validate_score_range(value: float, field_name: str, *, source: str) -> float:
+    parsed = _parse_float(value, field_name=field_name, source=source)
+    if parsed < 0.0 or parsed > 1.0:
+        raise OutcomeFeedbackError(f"{source}: {field_name} must be between 0.0 and 1.0")
+    return parsed
+
+
+def _camel_name(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(part.title() for part in tail)
+
+
+DEFAULT_FEEDBACK_ADJUSTMENT_POLICY = FeedbackAdjustmentPolicy()
 
 
 def _extract_selected_model(report: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/furyoku/runtime.py
+++ b/furyoku/runtime.py
@@ -13,7 +13,7 @@ from .model_decisions import (
     evaluate_model_decisions,
 )
 from .model_router import ModelEndpoint, ModelScore, RouterError, TaskProfile, select_model
-from .outcome_feedback import FeedbackAdjustmentInput
+from .outcome_feedback import FeedbackAdjustmentInput, FeedbackAdjustmentPolicyInput
 from .provider_adapters import (
     ProviderAdapter,
     ProviderExecutionRequest,
@@ -98,6 +98,7 @@ def route_and_execute(
     request: ProviderExecutionRequest | str,
     *,
     feedback: FeedbackAdjustmentInput | None = None,
+    feedback_policy: FeedbackAdjustmentPolicyInput | None = None,
     adapters: Mapping[str, ProviderAdapter] | None = None,
 ) -> RoutedExecutionResult:
     """Select the best eligible model for a task, then execute it."""
@@ -106,7 +107,7 @@ def route_and_execute(
     if feedback is None:
         selection = select_model(models, task)
     else:
-        report = evaluate_model_decisions(models, [task], feedback=feedback)
+        report = evaluate_model_decisions(models, [task], feedback=feedback, feedback_policy=feedback_policy)
         selection = report.selected_for(task.task_id)
         if selection is None:
             decision = report.situations[task.task_id]
@@ -127,11 +128,18 @@ def execute_decision_situation(
     *,
     readiness: ReadinessEvidenceInput | None = None,
     feedback: FeedbackAdjustmentInput | None = None,
+    feedback_policy: FeedbackAdjustmentPolicyInput | None = None,
     adapters: Mapping[str, ProviderAdapter] | None = None,
 ) -> DecisionSituationExecutionResult:
     """Run one calibrated decision situation using the same selection evidence as `decide`."""
 
-    report = evaluate_model_decisions(models, decision_input, readiness=readiness, feedback=feedback)
+    report = evaluate_model_decisions(
+        models,
+        decision_input,
+        readiness=readiness,
+        feedback=feedback,
+        feedback_policy=feedback_policy,
+    )
     try:
         decision = report.situations[situation_id]
     except KeyError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,16 @@ def write_feedback_log(path: Path) -> None:
     path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
 
+def write_feedback_policy(path: Path) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "maxAdjustment": 4.0,
+        "successBase": 1.0,
+        "successScoreMultiplier": 2.0,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def write_feedback_decision_suite(path: Path) -> None:
     payload = {
         "schemaVersion": 1,
@@ -552,6 +562,37 @@ class CliTests(unittest.TestCase):
             self.assertEqual(exit_code, 0)
             self.assertEqual(payload["modelId"], "local-echo")
             self.assertGreater(payload["feedbackAdjustments"]["local-echo"]["adjustment"], 0.0)
+
+    def test_select_feedback_policy_file_changes_adjustment(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "task.json"
+            feedback_path = Path(temp_dir) / "feedback.jsonl"
+            policy_path = Path(temp_dir) / "feedback-policy.json"
+            write_registry(registry_path)
+            write_feedback_task_profile(task_path)
+            write_feedback_log(feedback_path)
+            write_feedback_policy(policy_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "select",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                        "--feedback-log",
+                        str(feedback_path),
+                        "--feedback-policy",
+                        str(policy_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["feedbackAdjustments"]["local-echo"]["adjustment"], 3.0)
 
     def test_run_feedback_log_adjusts_single_task_executed_model(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_model_decisions.py
+++ b/tests/test_model_decisions.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from furyoku import (
     DecisionOutcomeRecord,
+    FeedbackAdjustmentPolicy,
     ModelDecisionError,
     ModelEndpoint,
     ModelReadinessEvidence,
@@ -259,6 +260,53 @@ class ModelDecisionTests(unittest.TestCase):
         self.assertEqual(selected.model.model_id, "local-gemma3-heretic")
         self.assertIn("local-gemma3-heretic", report.feedback_adjustments)
         self.assertTrue(any("outcome feedback adjustment" in reason for reason in local_rank.reasons))
+
+    def test_feedback_policy_changes_decision_adjustment_size(self):
+        task = TaskProfile(
+            task_id="feedback-chat",
+            required_capabilities={"conversation": 0.8},
+        )
+
+        default_report = evaluate_model_decisions(
+            sample_models()[:2],
+            [task],
+            feedback=[
+                DecisionOutcomeRecord(
+                    record_id="feedback-1",
+                    report_path="decision-report.json",
+                    report_sha256="0" * 64,
+                    generated_at="2026-04-10T12:00:00+00:00",
+                    selected_model_id="local-gemma3-heretic",
+                    selected_provider="local",
+                    verdict="success",
+                    score=1.0,
+                )
+            ],
+        )
+        policy_report = evaluate_model_decisions(
+            sample_models()[:2],
+            [task],
+            feedback=[
+                DecisionOutcomeRecord(
+                    record_id="feedback-1",
+                    report_path="decision-report.json",
+                    report_sha256="0" * 64,
+                    generated_at="2026-04-10T12:00:00+00:00",
+                    selected_model_id="local-gemma3-heretic",
+                    selected_provider="local",
+                    verdict="success",
+                    score=1.0,
+                )
+            ],
+            feedback_policy=FeedbackAdjustmentPolicy(
+                max_adjustment=3.0,
+                success_base=0.5,
+                success_score_multiplier=1.0,
+            ),
+        )
+
+        self.assertEqual(default_report.feedback_adjustments["local-gemma3-heretic"].adjustment, 10.0)
+        self.assertEqual(policy_report.feedback_adjustments["local-gemma3-heretic"].adjustment, 1.5)
 
     def test_feedback_adjustment_does_not_bypass_hard_blockers(self):
         task = TaskProfile(

--- a/tests/test_outcome_feedback.py
+++ b/tests/test_outcome_feedback.py
@@ -5,11 +5,14 @@ from pathlib import Path
 
 from furyoku import (
     DecisionOutcomeRecord,
+    FeedbackAdjustmentPolicy,
     OutcomeFeedbackError,
     append_decision_outcome,
     build_model_feedback_summaries,
     create_decision_outcome_record,
     load_decision_outcomes,
+    load_feedback_adjustment_policy,
+    parse_feedback_adjustment_policy,
 )
 
 
@@ -116,6 +119,89 @@ class OutcomeFeedbackTests(unittest.TestCase):
         self.assertLess(summaries["remote-model"].adjustment, 0.0)
         self.assertEqual(summaries["local-model"].manual_override_count, 1)
         self.assertTrue(any("bounded feedback adjustment" in reason for reason in summaries["local-model"].rationale))
+
+    def test_custom_feedback_policy_changes_adjustment_size(self):
+        records = [
+            DecisionOutcomeRecord(
+                record_id="1",
+                report_path="report.json",
+                report_sha256="0" * 64,
+                generated_at="2026-04-10T12:00:00+00:00",
+                selected_model_id="local-model",
+                selected_provider="local",
+                verdict="success",
+                score=1.0,
+            )
+        ]
+        policy = FeedbackAdjustmentPolicy(
+            max_adjustment=5.0,
+            success_base=1.0,
+            success_score_multiplier=2.0,
+        )
+
+        summaries = build_model_feedback_summaries(records, policy=policy)
+
+        self.assertEqual(summaries["local-model"].adjustment, 3.0)
+        self.assertEqual(summaries["local-model"].weighted_record_count, 1.0)
+
+    def test_feedback_policy_supports_recency_half_life(self):
+        records = [
+            DecisionOutcomeRecord(
+                record_id="new",
+                report_path="report.json",
+                report_sha256="0" * 64,
+                generated_at="2026-04-10T00:00:00+00:00",
+                selected_model_id="local-model",
+                selected_provider="local",
+                verdict="success",
+                score=1.0,
+            ),
+            DecisionOutcomeRecord(
+                record_id="old",
+                report_path="report.json",
+                report_sha256="1" * 64,
+                generated_at="2026-04-09T00:00:00+00:00",
+                selected_model_id="local-model",
+                selected_provider="local",
+                verdict="failure",
+            ),
+        ]
+
+        summaries = build_model_feedback_summaries(
+            records,
+            policy=FeedbackAdjustmentPolicy(recency_half_life_days=1.0),
+            as_of="2026-04-10T00:00:00+00:00",
+        )
+
+        self.assertGreater(summaries["local-model"].adjustment, 0.0)
+        self.assertEqual(summaries["local-model"].weighted_record_count, 1.5)
+        self.assertTrue(any("recency half-life" in reason for reason in summaries["local-model"].rationale))
+
+    def test_load_feedback_adjustment_policy_parses_json_contract(self):
+        payload = {
+            "schemaVersion": 1,
+            "maxAdjustment": 4.0,
+            "successBase": 1.5,
+            "successScoreMultiplier": 2.5,
+            "failurePenalty": -3.0,
+            "recencyHalfLifeDays": 7.0,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "policy.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            loaded = load_feedback_adjustment_policy(path)
+
+        parsed = parse_feedback_adjustment_policy(payload)
+        self.assertEqual(loaded, parsed)
+        self.assertEqual(loaded.max_adjustment, 4.0)
+        self.assertEqual(loaded.recency_half_life_days, 7.0)
+
+    def test_feedback_policy_rejects_invalid_values(self):
+        with self.assertRaises(OutcomeFeedbackError):
+            FeedbackAdjustmentPolicy(max_adjustment=-1.0)
+        with self.assertRaises(OutcomeFeedbackError):
+            parse_feedback_adjustment_policy({"schemaVersion": 1, "defaultSuccessScore": 1.5})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `FeedbackAdjustmentPolicy` as an explicit reusable contract for feedback scoring
- add JSON policy load/parse helpers and an example policy file
- pass `feedback_policy` through decision evaluation, decision-suite execution, and single-task execution
- add CLI `--feedback-policy` for `select`, `decide`, and `run`
- add optional recency half-life weighting while preserving default behavior

## Verification
- `python -m unittest tests.test_outcome_feedback tests.test_model_decisions tests.test_cli tests.test_runtime` (59 OK)
- `python -m unittest discover -s tests` (103 OK)
- `python benchmarks\\openclaw-local-llm\\test_benchmark_contract_report.py` (9 OK)
- `benchmarks\\openclaw-local-llm\\check_compare_truth_fresh.ps1` (fresh)
- `git diff --check` (clean; CRLF warnings only)
- CLI smoke: custom policy file produced `feedbackAdjustments.local-echo.adjustment == 3.0` through `select --feedback-policy` and `run --feedback-policy`

Note: ai-engineer specialist was spawned for #129, but did not return a final review before this PR publication. Parent verification is complete.

Closes #129