### PR TITLE
Update active FURYOKU lane to policy metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#129](https://github.com/JKhyro/FURYOKU/issues/129)
+- Current active lane: [#132](https://github.com/JKhyro/FURYOKU/issues/132)
 - Current downstream CHARACTER/MOA lane: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: make persisted outcome-feedback scoring configurable and policy-driven.
+- Current follow-on focus: surface feedback policy metadata in reports for runtime auditability.
 
 ## Product Direction
 


### PR DESCRIPTION
## Summary
- update README active lane from closed #129 to #132
- keep the primary runtime mandate pointed at feedback policy report auditability

## Verification
- `git diff --check`
- `python -m unittest tests.test_cli tests.test_runtime tests.test_model_decisions tests.test_outcome_feedback` (59 OK)

Refs #132