### PR TITLE
Update active FURYOKU lane to outcome capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#138](https://github.com/JKhyro/FURYOKU/issues/138)
-- Current downstream CHARACTER/MOA lane: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
+- Current active lane: [#141](https://github.com/JKhyro/FURYOKU/issues/141)
+- Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
 ## Current Baseline
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: add configurable routing score policy profiles so local/CLI/API selection can tune speed, cost, privacy, context, and provider preferences by situation.
+- Current follow-on focus: add execution outcome capture so routed runs can append reusable feedback evidence without hand-authored feedback logs.
 
 ## Product Direction
 


### PR DESCRIPTION
Updates README anchors after completed #138 so the active lane points to #141, the next primary runtime issue. Also records #97 as completed downstream CHARACTER/MOA groundwork instead of an active open lane.\n\nVerification: git diff --check (CRLF warning only); documentation-only active-lane anchor update.