### PR TITLE
Add cost and latency telemetry to outcome feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#163](https://github.com/JKhyro/FURYOKU/issues/163)
+- Current active lane: [#165](https://github.com/JKhyro/FURYOKU/issues/165)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: add aggregate feedback-backed model scorecards and per-situation leaderboards on top of the shared outcome evidence log.
+- Current follow-on focus: add observed latency plus available cost telemetry to the shared outcome evidence log, scorecards, and leaderboards.
 
 ## Product Direction
 
@@ -61,6 +61,7 @@ Current routing core:
 - Routed `run` executions can append inferred success/failure outcome records to JSONL feedback logs with `--output` plus `--capture-outcome-log`, allowing real execution results to become future routing evidence without hand-authored feedback entries.
 - Captured outcome feedback logs can be summarized by model, provider, and situation with diagnostic `rankScore` and feedback-adjustment signals for operator review.
 - `feedback-summary` also emits aggregate model scorecards and per-situation model leaderboards so operators can review long-run winners and failures across accumulated routed and comparative evidence.
+- Outcome feedback records preserve observed execution latency and any available model-rate or estimated cost telemetry already present in persisted run/comparison reports, so scorecards can surface speed and cost trends without changing routing blockers.
 - Feedback-backed recommendation reports reuse the current decision engine and explain the recommended model/provider per situation without changing routing policy.
 - Recommendation reports include additive confidence and evidence-quality metadata so operators can distinguish strong, sparse, mixed, and blocked recommendations.
 - [`examples/decision_outcomes.example.jsonl`](examples/decision_outcomes.example.jsonl) is a runnable outcome fixture for the summary and recommendation workflow.

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -873,7 +873,7 @@ def _readiness_from_args(args: argparse.Namespace, models):
 
 
 def _score_to_dict(selection: ModelScore) -> dict:
-    return {
+    payload = {
         "modelId": selection.model.model_id,
         "provider": selection.model.provider,
         "score": selection.score,
@@ -881,6 +881,11 @@ def _score_to_dict(selection: ModelScore) -> dict:
         "reasons": list(selection.reasons),
         "blockers": list(selection.blockers),
     }
+    if selection.model.input_cost_per_1k > 0.0:
+        payload["inputCostPer1k"] = selection.model.input_cost_per_1k
+    if selection.model.output_cost_per_1k > 0.0:
+        payload["outputCostPer1k"] = selection.model.output_cost_per_1k
+    return payload
 
 
 def _single_selection_to_dict(

--- a/furyoku/outcome_feedback.py
+++ b/furyoku/outcome_feedback.py
@@ -37,6 +37,12 @@ class DecisionOutcomeRecord:
     selected_model_id: str = ""
     selected_provider: str = ""
     execution_status: str = ""
+    latency_ms: float | None = None
+    input_cost_per_1k: float | None = None
+    output_cost_per_1k: float | None = None
+    estimated_input_cost: float | None = None
+    estimated_output_cost: float | None = None
+    estimated_total_cost: float | None = None
     score: float | None = None
     reason: str = ""
     tags: tuple[str, ...] = ()
@@ -55,6 +61,12 @@ class DecisionOutcomeRecord:
             "selectedModelId": self.selected_model_id,
             "selectedProvider": self.selected_provider,
             "executionStatus": self.execution_status,
+            "latencyMs": self.latency_ms,
+            "inputCostPer1k": self.input_cost_per_1k,
+            "outputCostPer1k": self.output_cost_per_1k,
+            "estimatedInputCost": self.estimated_input_cost,
+            "estimatedOutputCost": self.estimated_output_cost,
+            "estimatedTotalCost": self.estimated_total_cost,
             "verdict": self.verdict,
             "score": self.score,
             "reason": self.reason,
@@ -83,6 +95,36 @@ class DecisionOutcomeRecord:
             selected_model_id=str(payload.get("selectedModelId", payload.get("selected_model_id", "")) or ""),
             selected_provider=str(payload.get("selectedProvider", payload.get("selected_provider", "")) or ""),
             execution_status=str(payload.get("executionStatus", payload.get("execution_status", "")) or ""),
+            latency_ms=_optional_non_negative_float(
+                payload.get("latencyMs", payload.get("latency_ms")),
+                field_name="latencyMs",
+                source=source,
+            ),
+            input_cost_per_1k=_optional_non_negative_float(
+                payload.get("inputCostPer1k", payload.get("input_cost_per_1k")),
+                field_name="inputCostPer1k",
+                source=source,
+            ),
+            output_cost_per_1k=_optional_non_negative_float(
+                payload.get("outputCostPer1k", payload.get("output_cost_per_1k")),
+                field_name="outputCostPer1k",
+                source=source,
+            ),
+            estimated_input_cost=_optional_non_negative_float(
+                payload.get("estimatedInputCost", payload.get("estimated_input_cost")),
+                field_name="estimatedInputCost",
+                source=source,
+            ),
+            estimated_output_cost=_optional_non_negative_float(
+                payload.get("estimatedOutputCost", payload.get("estimated_output_cost")),
+                field_name="estimatedOutputCost",
+                source=source,
+            ),
+            estimated_total_cost=_optional_non_negative_float(
+                payload.get("estimatedTotalCost", payload.get("estimated_total_cost")),
+                field_name="estimatedTotalCost",
+                source=source,
+            ),
             verdict=verdict,
             score=score,
             reason=str(payload.get("reason", "") or ""),
@@ -260,6 +302,16 @@ class OutcomeFeedbackGroupSummary:
     adjustment: float | None = None
     weighted_record_count: float | None = None
     provider: str = ""
+    latency_record_count: int | None = None
+    average_latency_ms: float | None = None
+    minimum_latency_ms: float | None = None
+    maximum_latency_ms: float | None = None
+    cost_record_count: int | None = None
+    average_input_cost_per_1k: float | None = None
+    average_output_cost_per_1k: float | None = None
+    average_estimated_input_cost: float | None = None
+    average_estimated_output_cost: float | None = None
+    average_estimated_total_cost: float | None = None
 
     def to_dict(self) -> dict:
         payload = {
@@ -285,6 +337,26 @@ class OutcomeFeedbackGroupSummary:
             payload["weightedRecordCount"] = self.weighted_record_count
         if self.provider:
             payload["provider"] = self.provider
+        if self.latency_record_count is not None:
+            payload["latencyRecordCount"] = self.latency_record_count
+        if self.average_latency_ms is not None:
+            payload["averageLatencyMs"] = self.average_latency_ms
+        if self.minimum_latency_ms is not None:
+            payload["minimumLatencyMs"] = self.minimum_latency_ms
+        if self.maximum_latency_ms is not None:
+            payload["maximumLatencyMs"] = self.maximum_latency_ms
+        if self.cost_record_count is not None:
+            payload["costRecordCount"] = self.cost_record_count
+        if self.average_input_cost_per_1k is not None:
+            payload["averageInputCostPer1k"] = self.average_input_cost_per_1k
+        if self.average_output_cost_per_1k is not None:
+            payload["averageOutputCostPer1k"] = self.average_output_cost_per_1k
+        if self.average_estimated_input_cost is not None:
+            payload["averageEstimatedInputCost"] = self.average_estimated_input_cost
+        if self.average_estimated_output_cost is not None:
+            payload["averageEstimatedOutputCost"] = self.average_estimated_output_cost
+        if self.average_estimated_total_cost is not None:
+            payload["averageEstimatedTotalCost"] = self.average_estimated_total_cost
         return payload
 
 
@@ -373,10 +445,17 @@ class _OutcomeSummaryStats:
     key: str
     scores: list[float] = field(default_factory=list)
     generated_at_values: list[str] = field(default_factory=list)
+    latencies_ms: list[float] = field(default_factory=list)
+    input_costs_per_1k: list[float] = field(default_factory=list)
+    output_costs_per_1k: list[float] = field(default_factory=list)
+    estimated_input_costs: list[float] = field(default_factory=list)
+    estimated_output_costs: list[float] = field(default_factory=list)
+    estimated_total_costs: list[float] = field(default_factory=list)
     success_count: int = 0
     concern_count: int = 0
     failure_count: int = 0
     manual_override_count: int = 0
+    cost_record_count: int = 0
 
     @property
     def record_count(self) -> int:
@@ -387,6 +466,26 @@ class _OutcomeSummaryStats:
             self.scores.append(record.score)
         if record.generated_at:
             self.generated_at_values.append(record.generated_at)
+        if record.latency_ms is not None:
+            self.latencies_ms.append(record.latency_ms)
+        has_cost_telemetry = False
+        if record.input_cost_per_1k is not None:
+            self.input_costs_per_1k.append(record.input_cost_per_1k)
+            has_cost_telemetry = True
+        if record.output_cost_per_1k is not None:
+            self.output_costs_per_1k.append(record.output_cost_per_1k)
+            has_cost_telemetry = True
+        if record.estimated_input_cost is not None:
+            self.estimated_input_costs.append(record.estimated_input_cost)
+            has_cost_telemetry = True
+        if record.estimated_output_cost is not None:
+            self.estimated_output_costs.append(record.estimated_output_cost)
+            has_cost_telemetry = True
+        if record.estimated_total_cost is not None:
+            self.estimated_total_costs.append(record.estimated_total_cost)
+            has_cost_telemetry = True
+        if has_cost_telemetry:
+            self.cost_record_count += 1
         if record.verdict == "success":
             self.success_count += 1
         elif record.verdict == "failure":
@@ -395,6 +494,16 @@ class _OutcomeSummaryStats:
             self.concern_count += 1
         elif record.verdict == "manual_override":
             self.manual_override_count += 1
+
+
+@dataclass(frozen=True)
+class _OutcomeRecordTelemetry:
+    latency_ms: float | None = None
+    input_cost_per_1k: float | None = None
+    output_cost_per_1k: float | None = None
+    estimated_input_cost: float | None = None
+    estimated_output_cost: float | None = None
+    estimated_total_cost: float | None = None
 
 
 @dataclass(frozen=True)
@@ -526,6 +635,12 @@ def create_comparative_execution_outcome_records(
         if not execution_status:
             raise OutcomeFeedbackError(f"{path}: {capture.source_label}.execution.status is required")
         verdict = "success" if execution_status == "ok" else "failure"
+        telemetry = _extract_outcome_record_telemetry(
+            report=attempt,
+            execution=execution,
+            selection=selected,
+            source=f"{path}: {capture.source_label}",
+        )
         capture_metadata = {
             "captureSource": "furyoku.comparative-execution",
             "comparisonAttemptNumber": capture.comparison_attempt_number,
@@ -551,6 +666,12 @@ def create_comparative_execution_outcome_records(
                 selected_model_id=str(selected.get("modelId", "") or ""),
                 selected_provider=str(selected.get("provider", "") or ""),
                 execution_status=execution_status,
+                latency_ms=telemetry.latency_ms,
+                input_cost_per_1k=telemetry.input_cost_per_1k,
+                output_cost_per_1k=telemetry.output_cost_per_1k,
+                estimated_input_cost=telemetry.estimated_input_cost,
+                estimated_output_cost=telemetry.estimated_output_cost,
+                estimated_total_cost=telemetry.estimated_total_cost,
                 verdict=verdict,
                 score=normalized_success_score if verdict == "success" else normalized_failure_score,
                 reason=reason,
@@ -844,6 +965,12 @@ def _decision_outcome_record_from_report(
 ) -> DecisionOutcomeRecord:
     selection = _extract_selected_model(report)
     execution = report.get("execution")
+    telemetry = _extract_outcome_record_telemetry(
+        report=report,
+        execution=execution,
+        selection=selection,
+        source=str(path),
+    )
     return DecisionOutcomeRecord(
         record_id=str(uuid4()),
         report_path=str(path),
@@ -854,6 +981,12 @@ def _decision_outcome_record_from_report(
         selected_model_id=str(selection.get("modelId", "") or ""),
         selected_provider=str(selection.get("provider", "") or ""),
         execution_status=_execution_status(execution),
+        latency_ms=telemetry.latency_ms,
+        input_cost_per_1k=telemetry.input_cost_per_1k,
+        output_cost_per_1k=telemetry.output_cost_per_1k,
+        estimated_input_cost=telemetry.estimated_input_cost,
+        estimated_output_cost=telemetry.estimated_output_cost,
+        estimated_total_cost=telemetry.estimated_total_cost,
         verdict=verdict,
         score=score,
         reason=reason,
@@ -1057,6 +1190,16 @@ def _summarize_outcome_stats(
         adjustment=model_feedback.adjustment if model_feedback is not None else None,
         weighted_record_count=model_feedback.weighted_record_count if model_feedback is not None else None,
         provider=provider,
+        latency_record_count=len(stats.latencies_ms) or None,
+        average_latency_ms=_average_metric(stats.latencies_ms, digits=4),
+        minimum_latency_ms=_minimum_metric(stats.latencies_ms, digits=4),
+        maximum_latency_ms=_maximum_metric(stats.latencies_ms, digits=4),
+        cost_record_count=stats.cost_record_count or None,
+        average_input_cost_per_1k=_average_metric(stats.input_costs_per_1k, digits=6),
+        average_output_cost_per_1k=_average_metric(stats.output_costs_per_1k, digits=6),
+        average_estimated_input_cost=_average_metric(stats.estimated_input_costs, digits=6),
+        average_estimated_output_cost=_average_metric(stats.estimated_output_costs, digits=6),
+        average_estimated_total_cost=_average_metric(stats.estimated_total_costs, digits=6),
     )
 
 
@@ -1084,6 +1227,24 @@ def _outcome_rank_score(
 def _outcome_group_sort_key(summary: OutcomeFeedbackGroupSummary) -> tuple[float, float, int, str]:
     average_score = summary.average_score if summary.average_score is not None else -1.0
     return (-summary.rank_score, -summary.success_rate, -average_score, -summary.record_count, summary.key)
+
+
+def _average_metric(values: list[float], *, digits: int) -> float | None:
+    if not values:
+        return None
+    return round(sum(values) / len(values), digits)
+
+
+def _minimum_metric(values: list[float], *, digits: int) -> float | None:
+    if not values:
+        return None
+    return round(min(values), digits)
+
+
+def _maximum_metric(values: list[float], *, digits: int) -> float | None:
+    if not values:
+        return None
+    return round(max(values), digits)
 
 
 def _summary_generated_at(value: datetime | str | None) -> str:
@@ -1375,6 +1536,87 @@ def _report_generated_at(report: Mapping[str, Any]) -> str:
     return ""
 
 
+def _extract_outcome_record_telemetry(
+    *,
+    report: Mapping[str, Any],
+    execution: Any,
+    selection: Mapping[str, Any],
+    source: str,
+) -> _OutcomeRecordTelemetry:
+    telemetry_sources = _telemetry_sources(report=report, execution=execution, selection=selection)
+    return _OutcomeRecordTelemetry(
+        latency_ms=_first_optional_non_negative_float(
+            telemetry_sources,
+            ("elapsedMs", "elapsed_ms", "latencyMs", "latency_ms"),
+            source=source,
+        ),
+        input_cost_per_1k=_first_optional_non_negative_float(
+            telemetry_sources,
+            ("inputCostPer1k", "input_cost_per_1k"),
+            source=source,
+        ),
+        output_cost_per_1k=_first_optional_non_negative_float(
+            telemetry_sources,
+            ("outputCostPer1k", "output_cost_per_1k"),
+            source=source,
+        ),
+        estimated_input_cost=_first_optional_non_negative_float(
+            telemetry_sources,
+            ("estimatedInputCost", "estimated_input_cost", "inputCost", "input_cost"),
+            source=source,
+        ),
+        estimated_output_cost=_first_optional_non_negative_float(
+            telemetry_sources,
+            ("estimatedOutputCost", "estimated_output_cost", "outputCost", "output_cost"),
+            source=source,
+        ),
+        estimated_total_cost=_first_optional_non_negative_float(
+            telemetry_sources,
+            ("estimatedTotalCost", "estimated_total_cost", "totalCost", "total_cost"),
+            source=source,
+        ),
+    )
+
+
+def _telemetry_sources(
+    *,
+    report: Mapping[str, Any],
+    execution: Any,
+    selection: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    sources: list[Mapping[str, Any]] = []
+    _append_telemetry_source(sources, execution)
+    _append_telemetry_source(sources, selection)
+    _append_telemetry_source(sources, report.get("metadata"))
+    _append_telemetry_source(sources, report.get("telemetry"))
+    _append_telemetry_source(sources, report)
+    return tuple(sources)
+
+
+def _append_telemetry_source(sources: list[Mapping[str, Any]], value: Any) -> None:
+    if not isinstance(value, Mapping):
+        return
+    sources.append(value)
+    for nested_key in ("telemetry", "metadata", "cost", "usage"):
+        nested = value.get(nested_key)
+        if isinstance(nested, Mapping):
+            _append_telemetry_source(sources, nested)
+
+
+def _first_optional_non_negative_float(
+    sources: Iterable[Mapping[str, Any]],
+    keys: tuple[str, ...],
+    *,
+    source: str,
+) -> float | None:
+    for mapping in sources:
+        for key in keys:
+            if key not in mapping:
+                continue
+            return _optional_non_negative_float(mapping.get(key), field_name=key, source=source)
+    return None
+
+
 def _required_string(payload: Mapping[str, Any], *keys: str, source: str) -> str:
     for key in keys:
         value = payload.get(key)
@@ -1400,6 +1642,15 @@ def _optional_score(value: Any, *, source: str) -> float | None:
     if score < 0.0 or score > 1.0:
         raise OutcomeFeedbackError(f"{source}: score must be between 0.0 and 1.0")
     return round(score, 4)
+
+
+def _optional_non_negative_float(value: Any, *, field_name: str, source: str) -> float | None:
+    if value in (None, ""):
+        return None
+    parsed = _parse_float(value, field_name=field_name, source=source)
+    if parsed < 0.0:
+        raise OutcomeFeedbackError(f"{source}: {field_name} must be 0 or greater")
+    return round(parsed, 6)
 
 
 def _metadata_mapping(value: Any, *, source: str) -> Mapping[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,8 @@ def write_registry(path: Path) -> None:
                 "privacyLevel": "local",
                 "contextWindowTokens": 4096,
                 "averageLatencyMs": 10,
+                "inputCostPer1k": 0.0015,
+                "outputCostPer1k": 0.0045,
                 "invocation": [
                     sys.executable,
                     "-c",
@@ -37,6 +39,8 @@ def write_registry(path: Path) -> None:
                 "privacyLevel": "remote",
                 "contextWindowTokens": 128000,
                 "averageLatencyMs": 100,
+                "inputCostPer1k": 0.004,
+                "outputCostPer1k": 0.012,
                 "supportsTools": True,
                 "capabilities": {
                     "conversation": 0.8,
@@ -60,6 +64,8 @@ def write_executable_character_registry(path: Path) -> None:
                 "privacyLevel": "local",
                 "contextWindowTokens": 4096,
                 "averageLatencyMs": 10,
+                "inputCostPer1k": 0.0015,
+                "outputCostPer1k": 0.0045,
                 "invocation": [
                     sys.executable,
                     "-c",
@@ -77,6 +83,8 @@ def write_executable_character_registry(path: Path) -> None:
                 "privacyLevel": "remote",
                 "contextWindowTokens": 128000,
                 "averageLatencyMs": 20,
+                "inputCostPer1k": 0.0025,
+                "outputCostPer1k": 0.0075,
                 "invocation": [
                     sys.executable,
                     "-c",
@@ -122,6 +130,8 @@ def write_fallback_registry(path: Path) -> None:
                 "privacyLevel": "local",
                 "contextWindowTokens": 4096,
                 "averageLatencyMs": 10,
+                "inputCostPer1k": 0.002,
+                "outputCostPer1k": 0.006,
                 "invocation": [
                     sys.executable,
                     "-c",
@@ -139,6 +149,8 @@ def write_fallback_registry(path: Path) -> None:
                 "privacyLevel": "remote",
                 "contextWindowTokens": 128000,
                 "averageLatencyMs": 20,
+                "inputCostPer1k": 0.003,
+                "outputCostPer1k": 0.009,
                 "invocation": [
                     sys.executable,
                     "-c",
@@ -526,6 +538,9 @@ class CliTests(unittest.TestCase):
             self.assertEqual(logged[0]["tags"], ["auto-capture"])
             self.assertEqual(logged[0]["selectedModelId"], "local-echo")
             self.assertEqual(logged[0]["executionStatus"], "ok")
+            self.assertEqual(logged[0]["latencyMs"], payload["execution"]["elapsedMs"])
+            self.assertEqual(logged[0]["inputCostPer1k"], 0.0015)
+            self.assertEqual(logged[0]["outputCostPer1k"], 0.0045)
             self.assertEqual(logged[0]["reportSha256"], hashlib.sha256(report_bytes).hexdigest())
 
     def test_run_capture_outcome_requires_output_report(self):
@@ -704,6 +719,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["executions"][0]["execution"]["status"], "error")
             self.assertEqual(payload["executions"][1]["selectedModel"]["modelId"], "cli-fallback")
             self.assertEqual(payload["executions"][1]["execution"]["responseText"].strip(), "fallback:hello")
+            self.assertEqual(payload["executions"][0]["selectedModel"]["inputCostPer1k"], 0.002)
+            self.assertEqual(payload["executions"][1]["selectedModel"]["outputCostPer1k"], 0.009)
             self.assertEqual(persisted["comparison"]["executedCount"], 2)
             self.assertTrue(payload["comparisonOutcomeCapture"]["captured"])
             self.assertEqual(payload["comparisonOutcomeCapture"]["recordCount"], 2)
@@ -711,12 +728,16 @@ class CliTests(unittest.TestCase):
             self.assertEqual(logged[0]["selectedModelId"], "local-failing")
             self.assertEqual(logged[0]["verdict"], "failure")
             self.assertEqual(logged[0]["score"], 0.0)
+            self.assertEqual(logged[0]["latencyMs"], persisted["executions"][0]["execution"]["elapsedMs"])
+            self.assertEqual(logged[0]["inputCostPer1k"], 0.002)
             self.assertEqual(logged[0]["tags"], ["compare-run"])
             self.assertEqual(logged[0]["metadata"]["captureSource"], "furyoku.cli.compare-run")
             self.assertEqual(logged[0]["reportSha256"], hashlib.sha256(report_bytes).hexdigest())
             self.assertEqual(logged[1]["selectedModelId"], "cli-fallback")
             self.assertEqual(logged[1]["verdict"], "success")
             self.assertEqual(logged[1]["score"], 1.0)
+            self.assertEqual(logged[1]["latencyMs"], persisted["executions"][1]["execution"]["elapsedMs"])
+            self.assertEqual(logged[1]["outputCostPer1k"], 0.009)
 
     def test_compare_run_decision_suite_outputs_candidate_executions(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -843,6 +864,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["situations"][0]["situationId"], "fallback-chat")
             self.assertEqual(payload["situations"][0]["selectedModel"]["modelId"], "local-echo")
             self.assertEqual(payload["situations"][1]["selectedModel"]["modelId"], "cli-coder")
+            self.assertEqual(payload["situations"][0]["selectedModel"]["inputCostPer1k"], 0.0015)
+            self.assertEqual(payload["situations"][1]["selectedModel"]["outputCostPer1k"], 0.0075)
             self.assertEqual(persisted["comparison"]["successfulSituationCount"], 2)
             self.assertTrue(payload["comparisonOutcomeCapture"]["captured"])
             self.assertEqual(payload["comparisonOutcomeCapture"]["recordCount"], 2)
@@ -850,6 +873,15 @@ class CliTests(unittest.TestCase):
             self.assertEqual({record["situationId"] for record in logged}, {"fallback-chat", "tool-heavy-coding"})
             self.assertTrue(all(record["metadata"]["comparisonReportType"] == "compare-batch" for record in logged))
             self.assertTrue(all(record["metadata"]["captureSource"] == "furyoku.cli.compare-batch" for record in logged))
+            self.assertEqual(logged[0]["inputCostPer1k"], 0.0015)
+            self.assertEqual(logged[1]["outputCostPer1k"], 0.0075)
+            self.assertEqual(
+                {record["latencyMs"] for record in logged},
+                {
+                    persisted["situations"][0]["executions"][0]["execution"]["elapsedMs"],
+                    persisted["situations"][1]["executions"][0]["execution"]["elapsedMs"],
+                },
+            )
             self.assertEqual(logged[0]["reportSha256"], hashlib.sha256(report_bytes).hexdigest())
 
     def test_compare_batch_capture_comparison_outcomes_requires_output_report(self):
@@ -1071,6 +1103,12 @@ class CliTests(unittest.TestCase):
                         "selectedModelId": "local-echo",
                         "selectedProvider": "local",
                         "executionStatus": "ok",
+                        "latencyMs": 600.0,
+                        "inputCostPer1k": 0.0015,
+                        "outputCostPer1k": 0.0045,
+                        "estimatedInputCost": 0.0012,
+                        "estimatedOutputCost": 0.0024,
+                        "estimatedTotalCost": 0.0036,
                         "verdict": "success",
                         "score": 0.95,
                     }
@@ -1090,6 +1128,12 @@ class CliTests(unittest.TestCase):
                         "selectedModelId": "remote-coder",
                         "selectedProvider": "api",
                         "executionStatus": "error",
+                        "latencyMs": 1200.0,
+                        "inputCostPer1k": 0.004,
+                        "outputCostPer1k": 0.012,
+                        "estimatedInputCost": 0.0048,
+                        "estimatedOutputCost": 0.0096,
+                        "estimatedTotalCost": 0.0144,
                         "verdict": "failure",
                         "score": 0.1,
                     }
@@ -1118,14 +1162,22 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["recordCount"], 2)
             self.assertEqual(payload["total"]["successCount"], 1)
             self.assertEqual(payload["total"]["failureCount"], 1)
+            self.assertEqual(payload["total"]["latencyRecordCount"], 2)
+            self.assertEqual(payload["total"]["averageLatencyMs"], 900.0)
+            self.assertEqual(payload["total"]["costRecordCount"], 2)
+            self.assertEqual(payload["total"]["averageInputCostPer1k"], 0.00275)
+            self.assertEqual(payload["total"]["averageEstimatedTotalCost"], 0.009)
             self.assertEqual(payload["models"][0]["key"], "local-echo")
             self.assertIn("rankScore", payload["models"][0])
             self.assertEqual(payload["models"][0]["provider"], "local")
+            self.assertEqual(payload["models"][0]["averageLatencyMs"], 600.0)
             self.assertEqual({provider["key"] for provider in payload["providers"]}, {"local", "api"})
             self.assertEqual(payload["modelScorecards"][0]["modelId"], "local-echo")
             self.assertEqual(payload["modelScorecards"][0]["overall"]["provider"], "local")
+            self.assertEqual(payload["modelScorecards"][0]["overall"]["averageEstimatedTotalCost"], 0.0036)
             self.assertEqual(payload["situationLeaderboards"][0]["situationId"], "coding")
             self.assertEqual(payload["situationLeaderboards"][1]["situationId"], "private-chat")
+            self.assertEqual(payload["situationLeaderboards"][0]["models"][0]["averageLatencyMs"], 1200.0)
             self.assertIn("reportMetadata", persisted)
             self.assertEqual(persisted["recordCount"], 2)
 

--- a/tests/test_outcome_feedback.py
+++ b/tests/test_outcome_feedback.py
@@ -35,10 +35,17 @@ def write_execution_report(path: Path) -> None:
         "selectedModel": {
             "modelId": "local-gemma3-heretic-q4",
             "provider": "local",
+            "inputCostPer1k": 0.0015,
+            "outputCostPer1k": 0.0045,
         },
         "execution": {
             "status": "ok",
             "elapsedMs": 1200,
+            "usage": {
+                "estimatedInputCost": 0.0009,
+                "estimatedOutputCost": 0.0027,
+                "estimatedTotalCost": 0.0036,
+            },
         },
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -63,10 +70,18 @@ def write_comparison_report(path: Path) -> None:
                 "selectedModel": {
                     "modelId": "local-failing",
                     "provider": "local",
+                    "inputCostPer1k": 0.002,
+                    "outputCostPer1k": 0.006,
                 },
                 "execution": {
                     "status": "error",
+                    "elapsedMs": 1500,
                     "stderr": "local failed",
+                    "usage": {
+                        "estimatedInputCost": 0.0016,
+                        "estimatedOutputCost": 0.0,
+                        "estimatedTotalCost": 0.0016,
+                    },
                 },
             },
             {
@@ -74,10 +89,18 @@ def write_comparison_report(path: Path) -> None:
                 "selectedModel": {
                     "modelId": "cli-fallback",
                     "provider": "cli",
+                    "inputCostPer1k": 0.003,
+                    "outputCostPer1k": 0.009,
                 },
                 "execution": {
                     "status": "ok",
+                    "elapsedMs": 900,
                     "responseText": "fallback:hello",
+                    "usage": {
+                        "estimatedInputCost": 0.0024,
+                        "estimatedOutputCost": 0.0048,
+                        "estimatedTotalCost": 0.0072,
+                    },
                 },
             },
         ],
@@ -118,10 +141,18 @@ def write_comparison_batch_report(path: Path) -> None:
                         "selectedModel": {
                             "modelId": "local-failing",
                             "provider": "local",
+                            "inputCostPer1k": 0.002,
+                            "outputCostPer1k": 0.006,
                         },
                         "execution": {
                             "status": "error",
+                            "elapsedMs": 1400,
                             "stderr": "local failed",
+                            "usage": {
+                                "estimatedInputCost": 0.0014,
+                                "estimatedOutputCost": 0.0,
+                                "estimatedTotalCost": 0.0014,
+                            },
                         },
                     },
                     {
@@ -129,10 +160,18 @@ def write_comparison_batch_report(path: Path) -> None:
                         "selectedModel": {
                             "modelId": "cli-fallback",
                             "provider": "cli",
+                            "inputCostPer1k": 0.003,
+                            "outputCostPer1k": 0.009,
                         },
                         "execution": {
                             "status": "ok",
+                            "elapsedMs": 850,
                             "responseText": "fallback:hello",
+                            "usage": {
+                                "estimatedInputCost": 0.0021,
+                                "estimatedOutputCost": 0.0042,
+                                "estimatedTotalCost": 0.0063,
+                            },
                         },
                     },
                 ],
@@ -152,10 +191,18 @@ def write_comparison_batch_report(path: Path) -> None:
                         "selectedModel": {
                             "modelId": "cli-coder",
                             "provider": "cli",
+                            "inputCostPer1k": 0.004,
+                            "outputCostPer1k": 0.012,
                         },
                         "execution": {
                             "status": "ok",
+                            "elapsedMs": 650,
                             "responseText": "code:write code",
+                            "usage": {
+                                "estimatedInputCost": 0.0032,
+                                "estimatedOutputCost": 0.0064,
+                                "estimatedTotalCost": 0.0096,
+                            },
                         },
                     }
                 ],
@@ -196,6 +243,12 @@ class OutcomeFeedbackTests(unittest.TestCase):
         self.assertEqual(payload["selectedModelId"], "local-gemma3-heretic-q4")
         self.assertEqual(payload["selectedProvider"], "local")
         self.assertEqual(payload["executionStatus"], "ok")
+        self.assertEqual(payload["latencyMs"], 1200.0)
+        self.assertEqual(payload["inputCostPer1k"], 0.0015)
+        self.assertEqual(payload["outputCostPer1k"], 0.0045)
+        self.assertEqual(payload["estimatedInputCost"], 0.0009)
+        self.assertEqual(payload["estimatedOutputCost"], 0.0027)
+        self.assertEqual(payload["estimatedTotalCost"], 0.0036)
         self.assertEqual(payload["verdict"], "success")
         self.assertEqual(payload["score"], 0.92)
         self.assertEqual(payload["tags"], ["local", "private-chat"])
@@ -215,6 +268,8 @@ class OutcomeFeedbackTests(unittest.TestCase):
         self.assertEqual(loaded[0].record_id, record.record_id)
         self.assertEqual(loaded[0].verdict, "quality_concern")
         self.assertEqual(loaded[0].reason, "too terse")
+        self.assertEqual(loaded[0].latency_ms, 1200.0)
+        self.assertEqual(loaded[0].estimated_total_cost, 0.0036)
 
     def test_create_execution_outcome_record_infers_success_from_persisted_report(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -277,11 +332,17 @@ class OutcomeFeedbackTests(unittest.TestCase):
         self.assertEqual(records[0].verdict, "failure")
         self.assertEqual(records[0].score, 0.0)
         self.assertEqual(records[0].execution_status, "error")
+        self.assertEqual(records[0].latency_ms, 1500.0)
+        self.assertEqual(records[0].input_cost_per_1k, 0.002)
+        self.assertEqual(records[0].estimated_total_cost, 0.0016)
         self.assertEqual(records[0].metadata["comparisonAttemptNumber"], 1)
         self.assertEqual(records[0].metadata["operator"], "test")
         self.assertEqual(records[1].selected_model_id, "cli-fallback")
         self.assertEqual(records[1].verdict, "success")
         self.assertEqual(records[1].score, 1.0)
+        self.assertEqual(records[1].latency_ms, 900.0)
+        self.assertEqual(records[1].output_cost_per_1k, 0.009)
+        self.assertEqual(records[1].estimated_total_cost, 0.0072)
         self.assertEqual(records[1].metadata["comparisonExecutedCount"], 2)
 
     def test_capture_comparative_execution_outcomes_appends_all_candidate_records(self):
@@ -329,10 +390,15 @@ class OutcomeFeedbackTests(unittest.TestCase):
         self.assertEqual(records[0].metadata["comparisonSituationCount"], 3)
         self.assertEqual(records[0].metadata["comparisonBatchExecutedCandidateCount"], 3)
         self.assertEqual(records[0].metadata["operator"], "test")
+        self.assertEqual(records[0].latency_ms, 1400.0)
+        self.assertEqual(records[0].estimated_total_cost, 0.0014)
         self.assertEqual(records[2].situation_id, "tool-heavy-coding")
         self.assertEqual(records[2].selected_model_id, "cli-coder")
         self.assertEqual(records[2].verdict, "success")
         self.assertEqual(records[2].score, 1.0)
+        self.assertEqual(records[2].latency_ms, 650.0)
+        self.assertEqual(records[2].input_cost_per_1k, 0.004)
+        self.assertEqual(records[2].estimated_total_cost, 0.0096)
 
     def test_capture_comparative_execution_outcomes_skips_blocked_batch_situations(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -412,6 +478,12 @@ class OutcomeFeedbackTests(unittest.TestCase):
                 situation_id="private-chat",
                 selected_model_id="local-model",
                 selected_provider="local",
+                latency_ms=900.0,
+                input_cost_per_1k=0.001,
+                output_cost_per_1k=0.002,
+                estimated_input_cost=0.01,
+                estimated_output_cost=0.02,
+                estimated_total_cost=0.03,
                 verdict="success",
                 score=0.9,
             ),
@@ -423,6 +495,12 @@ class OutcomeFeedbackTests(unittest.TestCase):
                 situation_id="private-chat",
                 selected_model_id="local-model",
                 selected_provider="local",
+                latency_ms=1500.0,
+                input_cost_per_1k=0.001,
+                output_cost_per_1k=0.002,
+                estimated_input_cost=0.02,
+                estimated_output_cost=0.03,
+                estimated_total_cost=0.05,
                 verdict="failure",
                 score=0.2,
             ),
@@ -434,6 +512,12 @@ class OutcomeFeedbackTests(unittest.TestCase):
                 situation_id="coding",
                 selected_model_id="api-model",
                 selected_provider="api",
+                latency_ms=2000.0,
+                input_cost_per_1k=0.004,
+                output_cost_per_1k=0.012,
+                estimated_input_cost=0.04,
+                estimated_output_cost=0.08,
+                estimated_total_cost=0.12,
                 verdict="quality_concern",
                 score=0.4,
             ),
@@ -446,6 +530,12 @@ class OutcomeFeedbackTests(unittest.TestCase):
                 selected_model_id="api-model",
                 selected_provider="api",
                 override_model_id="local-model",
+                latency_ms=1000.0,
+                input_cost_per_1k=0.004,
+                output_cost_per_1k=0.012,
+                estimated_input_cost=0.03,
+                estimated_output_cost=0.05,
+                estimated_total_cost=0.08,
                 verdict="manual_override",
                 score=0.8,
             ),
@@ -461,19 +551,32 @@ class OutcomeFeedbackTests(unittest.TestCase):
         self.assertEqual(payload["total"]["concernCount"], 1)
         self.assertEqual(payload["total"]["manualOverrideCount"], 1)
         self.assertEqual(payload["total"]["averageScore"], 0.575)
+        self.assertEqual(payload["total"]["latencyRecordCount"], 4)
+        self.assertEqual(payload["total"]["averageLatencyMs"], 1350.0)
+        self.assertEqual(payload["total"]["minimumLatencyMs"], 900.0)
+        self.assertEqual(payload["total"]["maximumLatencyMs"], 2000.0)
+        self.assertEqual(payload["total"]["costRecordCount"], 4)
+        self.assertEqual(payload["total"]["averageInputCostPer1k"], 0.0025)
+        self.assertEqual(payload["total"]["averageOutputCostPer1k"], 0.007)
+        self.assertEqual(payload["total"]["averageEstimatedTotalCost"], 0.07)
         self.assertEqual(payload["models"][0]["key"], "local-model")
         self.assertGreater(payload["models"][0]["rankScore"], payload["models"][1]["rankScore"])
         self.assertEqual(payload["models"][0]["recordCount"], 2)
         self.assertEqual(payload["models"][0]["weightedRecordCount"], 3.0)
         self.assertEqual(payload["models"][0]["provider"], "local")
+        self.assertEqual(payload["models"][0]["averageLatencyMs"], 1200.0)
+        self.assertEqual(payload["models"][0]["averageEstimatedTotalCost"], 0.04)
         self.assertEqual(payload["providers"][0]["key"], "local")
         self.assertEqual([summary["key"] for summary in payload["situations"]], ["coding", "private-chat"])
         self.assertEqual(payload["modelScorecards"][0]["modelId"], "local-model")
         self.assertEqual(payload["modelScorecards"][0]["provider"], "local")
         self.assertEqual(payload["modelScorecards"][0]["overall"]["key"], "local-model")
         self.assertEqual(payload["modelScorecards"][0]["situations"][0]["key"], "private-chat")
+        self.assertEqual(payload["modelScorecards"][0]["overall"]["averageLatencyMs"], 1200.0)
         self.assertEqual(payload["situationLeaderboards"][0]["situationId"], "coding")
         self.assertEqual(payload["situationLeaderboards"][0]["models"][0]["key"], "api-model")
+        self.assertEqual(payload["situationLeaderboards"][0]["models"][0]["averageLatencyMs"], 1500.0)
+        self.assertEqual(payload["situationLeaderboards"][0]["models"][0]["averageEstimatedTotalCost"], 0.1)
         self.assertEqual(payload["feedbackPolicy"]["source"], "default")
 
     def test_summarize_outcome_feedback_accepts_empty_records(self):


### PR DESCRIPTION
## Summary
- add latency and cost telemetry fields to outcome feedback records and aggregate summaries
- preserve configured model cost rates in CLI-generated selection reports so captured run and comparison evidence can retain them
- extend outcome feedback and CLI coverage for telemetry capture and scorecard rollups

## Verification
- python -m unittest tests.test_outcome_feedback
- python -m unittest tests.test_cli.CliTests.test_run_capture_outcome_appends_inferred_success_record tests.test_cli.CliTests.test_compare_run_executes_eligible_models_and_persists_report tests.test_cli.CliTests.test_compare_batch_executes_suite_and_persists_aggregate_report tests.test_cli.CliTests.test_feedback_summary_merges_logs_and_persists_report
- python -m unittest discover -s tests
- python -m unittest discover -s benchmarks/openclaw-local-llm
- powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1

Closes #165