### PR TITLE
Add budget and latency routing constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#165](https://github.com/JKhyro/FURYOKU/issues/165)
+- Current active lane: [#167](https://github.com/JKhyro/FURYOKU/issues/167)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: add observed latency plus available cost telemetry to the shared outcome evidence log, scorecards, and leaderboards.
+- Current follow-on focus: consume captured latency and cost telemetry in budget-aware and latency-aware model decision constraints.
 
 ## Product Direction
 
@@ -62,6 +62,7 @@ Current routing core:
 - Captured outcome feedback logs can be summarized by model, provider, and situation with diagnostic `rankScore` and feedback-adjustment signals for operator review.
 - `feedback-summary` also emits aggregate model scorecards and per-situation model leaderboards so operators can review long-run winners and failures across accumulated routed and comparative evidence.
 - Outcome feedback records preserve observed execution latency and any available model-rate or estimated cost telemetry already present in persisted run/comparison reports, so scorecards can surface speed and cost trends without changing routing blockers.
+- Task profiles and decision-suite situations can apply explicit latency and total-cost ceilings so routed selection, recommendations, and comparative reviews favor the best model that is still usable within operator constraints.
 - Feedback-backed recommendation reports reuse the current decision engine and explain the recommended model/provider per situation without changing routing policy.
 - Recommendation reports include additive confidence and evidence-quality metadata so operators can distinguish strong, sparse, mixed, and blocked recommendations.
 - [`examples/decision_outcomes.example.jsonl`](examples/decision_outcomes.example.jsonl) is a runnable outcome fixture for the summary and recommendation workflow.

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -878,13 +878,17 @@ def _score_to_dict(selection: ModelScore) -> dict:
         "provider": selection.model.provider,
         "score": selection.score,
         "eligible": selection.eligible,
+        "averageLatencyMs": selection.model.average_latency_ms,
         "reasons": list(selection.reasons),
         "blockers": list(selection.blockers),
     }
+    total_cost_per_1k = selection.model.input_cost_per_1k + selection.model.output_cost_per_1k
     if selection.model.input_cost_per_1k > 0.0:
         payload["inputCostPer1k"] = selection.model.input_cost_per_1k
     if selection.model.output_cost_per_1k > 0.0:
         payload["outputCostPer1k"] = selection.model.output_cost_per_1k
+    if total_cost_per_1k > 0.0:
+        payload["totalCostPer1k"] = round(total_cost_per_1k, 6)
     return payload
 
 
@@ -895,6 +899,7 @@ def _single_selection_to_dict(
     readiness=None,
 ) -> dict:
     payload = _score_to_dict(selection)
+    payload["taskProfile"] = selection.task.to_dict()
     if report is not None:
         _add_optional_feedback_metadata(payload, report)
         _add_routing_policy_metadata(payload, report)
@@ -907,6 +912,7 @@ def _routed_result_to_dict(result: RoutedExecutionResult, *, readiness=None) -> 
     payload = {
         "ok": result.ok,
         "selection": _score_to_dict(result.selection),
+        "taskProfile": result.selection.task.to_dict(),
         "execution": _execution_to_dict(result.execution),
     }
     _add_execution_attempts(payload, result.execution_attempts)
@@ -1019,8 +1025,7 @@ def _decision_report_to_dict(report: ModelDecisionReport, *, readiness=None) -> 
         "blockedTasks": list(report.blocked_tasks),
         "decisions": [
             {
-                "taskId": decision.task.task_id,
-                "description": decision.task.description,
+                **decision.task.to_dict(),
                 "weight": decision.weight,
                 "minimumScore": decision.minimum_score,
                 "selectedModel": _score_to_dict(decision.selected) if decision.selected else None,

--- a/furyoku/model_decisions.py
+++ b/furyoku/model_decisions.py
@@ -72,7 +72,7 @@ class DecisionSuite:
             "description": self.description,
             "situations": [
                 {
-                    "taskId": task.task_id,
+                    **task.to_dict(),
                     "weight": self.weight_for(task.task_id),
                     "minimumScore": self.minimum_score_for(task.task_id),
                 }
@@ -134,8 +134,7 @@ class SituationDecision:
 
     def to_dict(self) -> dict:
         return {
-            "taskId": self.task.task_id,
-            "description": self.task.description,
+            **self.task.to_dict(),
             "eligible": self.eligible,
             "selectedModelId": self.selected.model.model_id if self.selected else None,
             "selectedProvider": self.selected.model.provider if self.selected else None,
@@ -1574,11 +1573,20 @@ def _round_weight(value: float) -> float:
 
 
 def _score_to_dict(score: ModelScore) -> dict:
-    return {
+    payload = {
         "modelId": score.model.model_id,
         "provider": score.model.provider,
         "score": score.score,
         "eligible": score.eligible,
+        "averageLatencyMs": score.model.average_latency_ms,
         "reasons": list(score.reasons),
         "blockers": list(score.blockers),
     }
+    if score.model.input_cost_per_1k > 0.0:
+        payload["inputCostPer1k"] = score.model.input_cost_per_1k
+    if score.model.output_cost_per_1k > 0.0:
+        payload["outputCostPer1k"] = score.model.output_cost_per_1k
+    total_cost_per_1k = score.model.input_cost_per_1k + score.model.output_cost_per_1k
+    if total_cost_per_1k > 0.0:
+        payload["totalCostPer1k"] = round(total_cost_per_1k, 6)
+    return payload

--- a/furyoku/model_router.py
+++ b/furyoku/model_router.py
@@ -195,11 +195,29 @@ class TaskProfile:
     description: str = ""
     min_context_tokens: int = 0
     privacy_requirement: PrivacyRequirement = "allow_remote"
+    max_latency_ms: int | None = None
     max_input_cost_per_1k: float | None = None
     max_output_cost_per_1k: float | None = None
+    max_total_cost_per_1k: float | None = None
     require_tools: bool = False
     require_json: bool = False
     preferred_providers: tuple[ProviderKind, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {
+            "taskId": self.task_id,
+            "description": self.description,
+            "requiredCapabilities": dict(self.required_capabilities),
+            "minContextTokens": self.min_context_tokens,
+            "privacyRequirement": self.privacy_requirement,
+            "maxLatencyMs": self.max_latency_ms,
+            "maxInputCostPer1k": self.max_input_cost_per_1k,
+            "maxOutputCostPer1k": self.max_output_cost_per_1k,
+            "maxTotalCostPer1k": self.max_total_cost_per_1k,
+            "requireTools": self.require_tools,
+            "requireJson": self.require_json,
+            "preferredProviders": list(self.preferred_providers),
+        }
 
 
 @dataclass(frozen=True)
@@ -303,6 +321,7 @@ def score_model(
     resolved_policy = resolve_routing_score_policy(policy)
     blockers: list[str] = []
     reasons: list[str] = []
+    total_cost_per_1k = model.input_cost_per_1k + model.output_cost_per_1k
 
     if not model.available:
         blockers.append("model is not currently available")
@@ -312,10 +331,28 @@ def score_model(
         )
     if task.privacy_requirement == "local_only" and not model.is_local:
         blockers.append("task requires a local model")
+    if task.max_latency_ms is not None:
+        if model.average_latency_ms > task.max_latency_ms:
+            blockers.append(
+                f"average latency {model.average_latency_ms}ms exceeds task limit {task.max_latency_ms}ms"
+            )
+        else:
+            reasons.append(
+                f"average latency {model.average_latency_ms}ms within task limit {task.max_latency_ms}ms"
+            )
     if task.max_input_cost_per_1k is not None and model.input_cost_per_1k > task.max_input_cost_per_1k:
         blockers.append("input cost exceeds task limit")
     if task.max_output_cost_per_1k is not None and model.output_cost_per_1k > task.max_output_cost_per_1k:
         blockers.append("output cost exceeds task limit")
+    if task.max_total_cost_per_1k is not None:
+        if total_cost_per_1k > task.max_total_cost_per_1k:
+            blockers.append(
+                f"total cost per 1k {total_cost_per_1k:.4f} exceeds task limit {task.max_total_cost_per_1k:.4f}"
+            )
+        else:
+            reasons.append(
+                f"total cost per 1k {total_cost_per_1k:.4f} within task limit {task.max_total_cost_per_1k:.4f}"
+            )
     if task.require_tools and not model.supports_tools:
         blockers.append("task requires tool support")
     if task.require_json and not model.supports_json:
@@ -351,10 +388,7 @@ def score_model(
         score += resolved_policy.preferred_provider_bonus
         reasons.append(f"preferred provider bonus for {model.provider}")
 
-    cost_penalty = min(
-        (model.input_cost_per_1k + model.output_cost_per_1k) * resolved_policy.cost_penalty_multiplier,
-        resolved_policy.max_cost_penalty,
-    )
+    cost_penalty = min(total_cost_per_1k * resolved_policy.cost_penalty_multiplier, resolved_policy.max_cost_penalty)
     if cost_penalty:
         score -= cost_penalty
         reasons.append(f"cost penalty {cost_penalty:.2f}")

--- a/furyoku/task_profiles.py
+++ b/furyoku/task_profiles.py
@@ -39,8 +39,16 @@ def parse_task_profile(payload: Mapping[str, Any], *, source: str = "<memory>") 
         required_capabilities={str(key): float(value) for key, value in raw_capabilities.items()},
         min_context_tokens=int(payload.get("minContextTokens", payload.get("min_context_tokens", 0)) or 0),
         privacy_requirement=str(payload.get("privacyRequirement", payload.get("privacy_requirement", "allow_remote"))),
-        max_input_cost_per_1k=_optional_float(payload.get("maxInputCostPer1k", payload.get("max_input_cost_per_1k"))),
-        max_output_cost_per_1k=_optional_float(payload.get("maxOutputCostPer1k", payload.get("max_output_cost_per_1k"))),
+        max_latency_ms=_optional_int(payload.get("maxLatencyMs", payload.get("max_latency_ms"))),
+        max_input_cost_per_1k=_optional_float(
+            payload.get("maxInputCostPer1k", payload.get("max_input_cost_per_1k"))
+        ),
+        max_output_cost_per_1k=_optional_float(
+            payload.get("maxOutputCostPer1k", payload.get("max_output_cost_per_1k"))
+        ),
+        max_total_cost_per_1k=_optional_float(
+            payload.get("maxTotalCostPer1k", payload.get("max_total_cost_per_1k"))
+        ),
         require_tools=bool(payload.get("requireTools", payload.get("require_tools", False))),
         require_json=bool(payload.get("requireJson", payload.get("require_json", False))),
         preferred_providers=tuple(str(item) for item in payload.get("preferredProviders", payload.get("preferred_providers", ()))),
@@ -50,4 +58,16 @@ def parse_task_profile(payload: Mapping[str, Any], *, source: str = "<memory>") 
 def _optional_float(value: Any) -> float | None:
     if value in (None, ""):
         return None
-    return float(value)
+    parsed = float(value)
+    if parsed < 0.0:
+        raise TaskProfileError("optional float fields must be 0 or greater")
+    return round(parsed, 6)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    parsed = int(value)
+    if parsed < 0:
+        raise TaskProfileError("optional integer fields must be 0 or greater")
+    return parsed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,6 +185,17 @@ def write_feedback_task_profile(path: Path) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def write_budget_latency_task_profile(path: Path) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "taskId": "bounded-chat",
+        "requiredCapabilities": {"conversation": 0.8},
+        "maxLatencyMs": 20,
+        "maxTotalCostPer1k": 0.01,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def write_feedback_log(path: Path) -> None:
     payload = {
         "schemaVersion": 1,
@@ -458,6 +469,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["modelId"], "local-echo")
             self.assertEqual(payload["provider"], "local")
             self.assertTrue(payload["eligible"])
+            self.assertEqual(payload["averageLatencyMs"], 10)
+            self.assertEqual(payload["totalCostPer1k"], 0.006)
 
     def test_run_executes_selected_local_model(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1404,6 +1417,66 @@ class CliTests(unittest.TestCase):
             payload = json.loads(stdout.getvalue())
             self.assertEqual(exit_code, 0)
             self.assertEqual(payload["modelId"], "local-echo")
+            self.assertEqual(payload["taskProfile"]["taskId"], "private-chat")
+
+    def test_select_output_surfaces_budget_and_latency_constraints(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "budget-task.json"
+            write_registry(registry_path)
+            write_budget_latency_task_profile(task_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "select",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["modelId"], "local-echo")
+            self.assertEqual(payload["taskProfile"]["maxLatencyMs"], 20)
+            self.assertEqual(payload["taskProfile"]["maxTotalCostPer1k"], 0.01)
+
+    def test_decide_surfaces_budget_and_latency_constraint_blockers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "budget-task.json"
+            write_registry(registry_path)
+            write_budget_latency_task_profile(task_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "decide",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            decision = payload["decisions"][0]
+            remote_rank = next(
+                score for score in decision["rankedModels"] if score["modelId"] == "remote-coder"
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(decision["maxLatencyMs"], 20)
+            self.assertEqual(decision["maxTotalCostPer1k"], 0.01)
+            self.assertEqual(decision["selectedModel"]["modelId"], "local-echo")
+            self.assertFalse(remote_rank["eligible"])
+            self.assertTrue(
+                any("average latency 100ms exceeds task limit 20ms" in blocker for blocker in remote_rank["blockers"])
+            )
+            self.assertEqual(remote_rank["totalCostPer1k"], 0.016)
 
     def test_select_feedback_log_adjusts_single_task_ranking(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_model_decisions.py
+++ b/tests/test_model_decisions.py
@@ -233,6 +233,56 @@ class ModelDecisionTests(unittest.TestCase):
         self.assertEqual(decision.selected.model.model_id, "api-primary")
         self.assertTrue(any("provider readiness ready" in reason for reason in decision.selected.reasons))
 
+    def test_decision_output_preserves_latency_and_budget_constraints(self):
+        task = TaskProfile(
+            task_id="bounded-chat",
+            required_capabilities={"conversation": 0.8},
+            max_latency_ms=2000,
+            max_total_cost_per_1k=0.03,
+        )
+
+        report = evaluate_model_decisions(sample_models(), [task])
+        payload = report.to_dict()
+        decision = payload["decisions"][0]
+        blocked = next(score for score in decision["ranked"] if score["modelId"] == "cli-codex-high")
+
+        self.assertEqual(decision["taskId"], "bounded-chat")
+        self.assertEqual(decision["maxLatencyMs"], 2000)
+        self.assertEqual(decision["maxTotalCostPer1k"], 0.03)
+        self.assertEqual(decision["selectedModelId"], "local-gemma3-heretic")
+        self.assertFalse(blocked["eligible"])
+        self.assertTrue(
+            any("average latency 6000ms exceeds task limit 2000ms" in blocker for blocker in blocked["blockers"])
+        )
+        self.assertEqual(blocked["averageLatencyMs"], 6000)
+        self.assertEqual(blocked["totalCostPer1k"], 0.1)
+
+    def test_decision_suite_to_dict_includes_task_constraint_fields(self):
+        suite = parse_decision_suite(
+            {
+                "schemaVersion": 1,
+                "suiteId": "constraint-suite",
+                "situations": [
+                    {
+                        "taskId": "bounded-chat",
+                        "requiredCapabilities": {"conversation": 0.8},
+                        "maxLatencyMs": 2000,
+                        "maxTotalCostPer1k": 0.03,
+                        "weight": 2.0,
+                        "minimumScore": 40.0,
+                    }
+                ],
+            }
+        )
+
+        situation = suite.to_dict()["situations"][0]
+
+        self.assertEqual(situation["taskId"], "bounded-chat")
+        self.assertEqual(situation["maxLatencyMs"], 2000)
+        self.assertEqual(situation["maxTotalCostPer1k"], 0.03)
+        self.assertEqual(situation["weight"], 2.0)
+        self.assertEqual(situation["minimumScore"], 40.0)
+
     def test_feedback_adjustment_can_promote_eligible_model(self):
         task = TaskProfile(
             task_id="feedback-chat",

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -196,6 +196,74 @@ class ModelRouterTests(unittest.TestCase):
         self.assertEqual(default_selected.model.model_id, "expensive-api")
         self.assertEqual(cheap_selected.model.model_id, "cheap-local")
 
+    def test_latency_ceiling_blocks_slow_models(self):
+        models = [
+            ModelEndpoint(
+                model_id="fast-local",
+                provider="local",
+                privacy_level="local",
+                context_window_tokens=4096,
+                average_latency_ms=100,
+                capabilities={"conversation": 0.82},
+            ),
+            ModelEndpoint(
+                model_id="slow-remote",
+                provider="api",
+                privacy_level="remote",
+                context_window_tokens=128000,
+                average_latency_ms=5000,
+                capabilities={"conversation": 0.95},
+            ),
+        ]
+        task = TaskProfile(
+            task_id="bounded-latency-chat",
+            required_capabilities={"conversation": 0.8},
+            max_latency_ms=1000,
+        )
+
+        ranked = rank_models(models, task)
+        slow_remote = next(score for score in ranked if score.model.model_id == "slow-remote")
+
+        self.assertEqual(select_model(models, task).model.model_id, "fast-local")
+        self.assertFalse(slow_remote.eligible)
+        self.assertTrue(any("average latency 5000ms exceeds task limit 1000ms" in blocker for blocker in slow_remote.blockers))
+
+    def test_total_cost_ceiling_blocks_expensive_models(self):
+        models = [
+            ModelEndpoint(
+                model_id="cheap-local",
+                provider="local",
+                privacy_level="local",
+                context_window_tokens=4096,
+                average_latency_ms=1200,
+                input_cost_per_1k=0.0,
+                output_cost_per_1k=0.0,
+                capabilities={"summarization": 0.82},
+            ),
+            ModelEndpoint(
+                model_id="expensive-api",
+                provider="api",
+                privacy_level="remote",
+                context_window_tokens=128000,
+                average_latency_ms=1200,
+                input_cost_per_1k=0.08,
+                output_cost_per_1k=0.12,
+                capabilities={"summarization": 0.95},
+            ),
+        ]
+        task = TaskProfile(
+            task_id="budget-summary",
+            required_capabilities={"summarization": 0.8},
+            max_total_cost_per_1k=0.1,
+        )
+
+        ranked = rank_models(models, task)
+        expensive_api = next(score for score in ranked if score.model.model_id == "expensive-api")
+
+        self.assertEqual(select_model(models, task).model.model_id, "cheap-local")
+        self.assertFalse(expensive_api.eligible)
+        self.assertTrue(any("total cost per 1k 0.2000 exceeds task limit 0.1000" in blocker for blocker in expensive_api.blockers))
+
     def test_score_policy_does_not_bypass_hard_blockers(self):
         task = TaskProfile(
             task_id="tool-coding",

--- a/tests/test_task_profiles.py
+++ b/tests/test_task_profiles.py
@@ -32,6 +32,24 @@ class TaskProfileTests(unittest.TestCase):
 
         self.assertEqual(profile.task_id, "bom-task")
 
+    def test_parse_task_profile_accepts_budget_and_latency_constraints(self):
+        profile = parse_task_profile(
+            {
+                "schemaVersion": 1,
+                "taskId": "bounded-task",
+                "requiredCapabilities": {"conversation": 0.8},
+                "maxLatencyMs": 2500,
+                "maxInputCostPer1k": 0.01,
+                "maxOutputCostPer1k": 0.02,
+                "maxTotalCostPer1k": 0.025,
+            }
+        )
+
+        self.assertEqual(profile.max_latency_ms, 2500)
+        self.assertEqual(profile.max_input_cost_per_1k, 0.01)
+        self.assertEqual(profile.max_output_cost_per_1k, 0.02)
+        self.assertEqual(profile.max_total_cost_per_1k, 0.025)
+
     def test_missing_capabilities_are_rejected(self):
         with self.assertRaises(TaskProfileError) as error:
             parse_task_profile({"schemaVersion": 1, "taskId": "broken"})


### PR DESCRIPTION
## Summary
- add max-latency and max-total-cost routing constraints to task and decision contracts
- enforce those constraints as hard blockers with explicit audit reasons in router and decision outputs
- surface constraint and cost/latency data through CLI JSON and add focused router/decision/CLI coverage

## Verification
- python -m unittest tests.test_task_profiles tests.test_model_router tests.test_model_decisions
- python -m unittest tests.test_cli.CliTests.test_select_outputs_selected_model_json tests.test_cli.CliTests.test_select_accepts_task_profile_file tests.test_cli.CliTests.test_select_output_surfaces_budget_and_latency_constraints tests.test_cli.CliTests.test_decide_surfaces_budget_and_latency_constraint_blockers
- python -m unittest discover -s tests
- python -m unittest discover -s benchmarks/openclaw-local-llm
- powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1

Closes #167