### PR TITLE
Add task-level routing tradeoff weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#167](https://github.com/JKhyro/FURYOKU/issues/167)
+- Current active lane: [#169](https://github.com/JKhyro/FURYOKU/issues/169)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: consume captured latency and cost telemetry in budget-aware and latency-aware model decision constraints.
+- Current follow-on focus: add task-level soft tradeoff weighting so otherwise-eligible model decisions can deliberately bias quality, latency, and cost without bypassing hard blockers.
 
 ## Product Direction
 
@@ -81,6 +81,7 @@ Current routing core:
 - [`examples/comparison_prompt_map.primary-routing.json`](examples/comparison_prompt_map.primary-routing.json) shows a reusable prompt-map for suite-level comparative execution batches.
 - Decision suites can weight higher-value situations and define minimum score thresholds so FURYOKU can distinguish "best available" from "good enough to use."
 - [`examples/task_profile.private-chat.json`](examples/task_profile.private-chat.json) shows reusable task profile configuration.
+- [`examples/task_profile.tradeoff-speed-chat.json`](examples/task_profile.tradeoff-speed-chat.json) shows task-level soft tradeoff weighting for a latency-sensitive chat task.
 - [`examples/character_profile.tertiary-symbiote.json`](examples/character_profile.tertiary-symbiote.json) shows a one-role tertiary Symbiote composition.
 - [`examples/character_profile.kira-array.json`](examples/character_profile.kira-array.json) shows a larger Kira-style one-primary/seven-secondary role array.
 - [`tests/test_character_profiles.py`](tests/test_character_profiles.py) verifies flexible CHARACTER profile loading and validation.

--- a/examples/task_profile.tradeoff-speed-chat.json
+++ b/examples/task_profile.tradeoff-speed-chat.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "taskId": "tradeoff-speed-chat",
+  "description": "Conversational task that still values quality, but deliberately prefers lower latency among otherwise eligible models.",
+  "privacyRequirement": "allow_remote",
+  "requiredCapabilities": {
+    "conversation": 0.8,
+    "instruction_following": 0.75
+  },
+  "qualityTradeoffWeight": 1.0,
+  "latencyTradeoffWeight": 2.5,
+  "costTradeoffWeight": 1.0
+}

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -702,12 +702,30 @@ def _add_common_task_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--max-input-cost-per-1k", type=float, default=None, help="Maximum input cost per 1k tokens.")
     parser.add_argument("--max-output-cost-per-1k", type=float, default=None, help="Maximum output cost per 1k tokens.")
+    parser.add_argument(
+        "--quality-tradeoff-weight",
+        type=_parse_non_negative_float_arg,
+        default=None,
+        help="Task-level soft weighting applied to quality/capability and context scoring.",
+    )
+    parser.add_argument(
+        "--latency-tradeoff-weight",
+        type=_parse_non_negative_float_arg,
+        default=None,
+        help="Task-level soft weighting applied to latency/speed scoring.",
+    )
+    parser.add_argument(
+        "--cost-tradeoff-weight",
+        type=_parse_non_negative_float_arg,
+        default=None,
+        help="Task-level soft weighting applied to cost penalties.",
+    )
 
 
 def _task_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> TaskProfile:
     if args.task_profile:
         profile = load_task_profile(args.task_profile)
-        if not args.capability and not args.task_id:
+        if not _task_profile_has_inline_overrides(args):
             return profile
         return TaskProfile(
             task_id=args.task_id or profile.task_id,
@@ -715,15 +733,26 @@ def _task_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -
             required_capabilities=_parse_capabilities(args.capability) if args.capability else profile.required_capabilities,
             min_context_tokens=args.min_context_tokens or profile.min_context_tokens,
             privacy_requirement=args.privacy if args.privacy != "allow_remote" else profile.privacy_requirement,
+            max_latency_ms=profile.max_latency_ms,
             max_input_cost_per_1k=args.max_input_cost_per_1k
             if args.max_input_cost_per_1k is not None
             else profile.max_input_cost_per_1k,
             max_output_cost_per_1k=args.max_output_cost_per_1k
             if args.max_output_cost_per_1k is not None
             else profile.max_output_cost_per_1k,
+            max_total_cost_per_1k=profile.max_total_cost_per_1k,
             require_tools=args.require_tools or profile.require_tools,
             require_json=args.require_json or profile.require_json,
             preferred_providers=tuple(args.preferred_provider) or profile.preferred_providers,
+            quality_tradeoff_weight=args.quality_tradeoff_weight
+            if args.quality_tradeoff_weight is not None
+            else profile.quality_tradeoff_weight,
+            latency_tradeoff_weight=args.latency_tradeoff_weight
+            if args.latency_tradeoff_weight is not None
+            else profile.latency_tradeoff_weight,
+            cost_tradeoff_weight=args.cost_tradeoff_weight
+            if args.cost_tradeoff_weight is not None
+            else profile.cost_tradeoff_weight,
         )
 
     if not args.task_id:
@@ -741,6 +770,29 @@ def _task_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -
         require_tools=args.require_tools,
         require_json=args.require_json,
         preferred_providers=tuple(args.preferred_provider),
+        quality_tradeoff_weight=args.quality_tradeoff_weight or 1.0,
+        latency_tradeoff_weight=args.latency_tradeoff_weight or 1.0,
+        cost_tradeoff_weight=args.cost_tradeoff_weight or 1.0,
+    )
+
+
+def _task_profile_has_inline_overrides(args: argparse.Namespace) -> bool:
+    return any(
+        (
+            bool(args.capability),
+            bool(args.task_id),
+            bool(args.description),
+            bool(args.min_context_tokens),
+            args.privacy != "allow_remote",
+            args.require_tools,
+            args.require_json,
+            bool(args.preferred_provider),
+            args.max_input_cost_per_1k is not None,
+            args.max_output_cost_per_1k is not None,
+            args.quality_tradeoff_weight is not None,
+            args.latency_tradeoff_weight is not None,
+            args.cost_tradeoff_weight is not None,
+        )
     )
 
 
@@ -761,6 +813,16 @@ def _parse_capabilities(raw_values: Sequence[str]) -> dict[str, float]:
             raise argparse.ArgumentTypeError(f"capability score must be between 0.0 and 1.0: {raw_value}")
         capabilities[name] = score
     return capabilities
+
+
+def _parse_non_negative_float_arg(raw_value: str) -> float:
+    try:
+        value = float(raw_value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"value must be numeric: {raw_value}") from exc
+    if value < 0.0:
+        raise argparse.ArgumentTypeError(f"value must be 0 or greater: {raw_value}")
+    return value
 
 
 def _select_with_optional_feedback(

--- a/furyoku/model_router.py
+++ b/furyoku/model_router.py
@@ -202,6 +202,17 @@ class TaskProfile:
     require_tools: bool = False
     require_json: bool = False
     preferred_providers: tuple[ProviderKind, ...] = ()
+    quality_tradeoff_weight: float = 1.0
+    latency_tradeoff_weight: float = 1.0
+    cost_tradeoff_weight: float = 1.0
+
+    @property
+    def has_custom_tradeoff_weights(self) -> bool:
+        return not (
+            math.isclose(self.quality_tradeoff_weight, 1.0)
+            and math.isclose(self.latency_tradeoff_weight, 1.0)
+            and math.isclose(self.cost_tradeoff_weight, 1.0)
+        )
 
     def to_dict(self) -> dict:
         return {
@@ -217,6 +228,9 @@ class TaskProfile:
             "requireTools": self.require_tools,
             "requireJson": self.require_json,
             "preferredProviders": list(self.preferred_providers),
+            "qualityTradeoffWeight": self.quality_tradeoff_weight,
+            "latencyTradeoffWeight": self.latency_tradeoff_weight,
+            "costTradeoffWeight": self.cost_tradeoff_weight,
         }
 
 
@@ -322,6 +336,9 @@ def score_model(
     blockers: list[str] = []
     reasons: list[str] = []
     total_cost_per_1k = model.input_cost_per_1k + model.output_cost_per_1k
+    quality_tradeoff_weight = task.quality_tradeoff_weight
+    latency_tradeoff_weight = task.latency_tradeoff_weight
+    cost_tradeoff_weight = task.cost_tradeoff_weight
 
     if not model.available:
         blockers.append("model is not currently available")
@@ -359,13 +376,21 @@ def score_model(
         blockers.append("task requires JSON output support")
 
     capability_score = _weighted_capability_score(model, task)
-    score = capability_score * resolved_policy.capability_weight
+    if task.has_custom_tradeoff_weights:
+        reasons.append(
+            "tradeoff weights "
+            f"quality {quality_tradeoff_weight:.2f}, "
+            f"latency {latency_tradeoff_weight:.2f}, "
+            f"cost {cost_tradeoff_weight:.2f}"
+        )
+    score = capability_score * resolved_policy.capability_weight * quality_tradeoff_weight
     reasons.append(f"capability fit {capability_score:.3f}")
 
     if model.context_window_tokens >= task.min_context_tokens:
         context_bonus = (
             min(model.context_window_tokens / resolved_policy.context_reference_tokens, 1.0)
             * resolved_policy.context_bonus_weight
+            * quality_tradeoff_weight
         )
         score += context_bonus
         reasons.append(f"context bonus {context_bonus:.2f}")
@@ -373,6 +398,7 @@ def score_model(
     speed_bonus = (
         max(0.0, min(1.0, 1.0 - (model.average_latency_ms / resolved_policy.speed_reference_ms)))
         * resolved_policy.speed_bonus_weight
+        * latency_tradeoff_weight
     )
     score += speed_bonus
     reasons.append(f"speed bonus {speed_bonus:.2f}")
@@ -388,7 +414,10 @@ def score_model(
         score += resolved_policy.preferred_provider_bonus
         reasons.append(f"preferred provider bonus for {model.provider}")
 
-    cost_penalty = min(total_cost_per_1k * resolved_policy.cost_penalty_multiplier, resolved_policy.max_cost_penalty)
+    cost_penalty = (
+        min(total_cost_per_1k * resolved_policy.cost_penalty_multiplier, resolved_policy.max_cost_penalty)
+        * cost_tradeoff_weight
+    )
     if cost_penalty:
         score -= cost_penalty
         reasons.append(f"cost penalty {cost_penalty:.2f}")

--- a/furyoku/task_profiles.py
+++ b/furyoku/task_profiles.py
@@ -51,7 +51,24 @@ def parse_task_profile(payload: Mapping[str, Any], *, source: str = "<memory>") 
         ),
         require_tools=bool(payload.get("requireTools", payload.get("require_tools", False))),
         require_json=bool(payload.get("requireJson", payload.get("require_json", False))),
-        preferred_providers=tuple(str(item) for item in payload.get("preferredProviders", payload.get("preferred_providers", ()))),
+        preferred_providers=tuple(
+            str(item) for item in payload.get("preferredProviders", payload.get("preferred_providers", ()))
+        ),
+        quality_tradeoff_weight=_non_negative_float(
+            payload.get("qualityTradeoffWeight", payload.get("quality_tradeoff_weight")),
+            default=1.0,
+            field_name="qualityTradeoffWeight",
+        ),
+        latency_tradeoff_weight=_non_negative_float(
+            payload.get("latencyTradeoffWeight", payload.get("latency_tradeoff_weight")),
+            default=1.0,
+            field_name="latencyTradeoffWeight",
+        ),
+        cost_tradeoff_weight=_non_negative_float(
+            payload.get("costTradeoffWeight", payload.get("cost_tradeoff_weight")),
+            default=1.0,
+            field_name="costTradeoffWeight",
+        ),
     )
 
 
@@ -71,3 +88,12 @@ def _optional_int(value: Any) -> int | None:
     if parsed < 0:
         raise TaskProfileError("optional integer fields must be 0 or greater")
     return parsed
+
+
+def _non_negative_float(value: Any, *, default: float, field_name: str) -> float:
+    if value in (None, ""):
+        return default
+    parsed = float(value)
+    if parsed < 0.0:
+        raise TaskProfileError(f"{field_name} must be 0 or greater")
+    return round(parsed, 6)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,18 @@ def write_budget_latency_task_profile(path: Path) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def write_tradeoff_task_profile(path: Path) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "taskId": "tradeoff-chat",
+        "requiredCapabilities": {"conversation": 0.8},
+        "qualityTradeoffWeight": 0.4,
+        "latencyTradeoffWeight": 3.0,
+        "costTradeoffWeight": 3.0,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def write_feedback_log(path: Path) -> None:
     payload = {
         "schemaVersion": 1,
@@ -1477,6 +1489,68 @@ class CliTests(unittest.TestCase):
                 any("average latency 100ms exceeds task limit 20ms" in blocker for blocker in remote_rank["blockers"])
             )
             self.assertEqual(remote_rank["totalCostPer1k"], 0.016)
+
+    def test_select_output_surfaces_tradeoff_weights_from_task_profile(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "tradeoff-task.json"
+            write_routing_policy_registry(registry_path)
+            write_tradeoff_task_profile(task_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "select",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["modelId"], "fast-local")
+            self.assertEqual(payload["taskProfile"]["qualityTradeoffWeight"], 0.4)
+            self.assertEqual(payload["taskProfile"]["latencyTradeoffWeight"], 3.0)
+            self.assertEqual(payload["taskProfile"]["costTradeoffWeight"], 3.0)
+            self.assertTrue(
+                any("tradeoff weights quality 0.40, latency 3.00, cost 3.00" in reason for reason in payload["reasons"])
+            )
+
+    def test_select_task_profile_tradeoff_flags_override_profile_defaults(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            task_path = Path(temp_dir) / "task.json"
+            write_routing_policy_registry(registry_path)
+            write_feedback_task_profile(task_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "select",
+                        "--registry",
+                        str(registry_path),
+                        "--task-profile",
+                        str(task_path),
+                        "--quality-tradeoff-weight",
+                        "0.4",
+                        "--latency-tradeoff-weight",
+                        "3.0",
+                        "--cost-tradeoff-weight",
+                        "3.0",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["modelId"], "fast-local")
+            self.assertEqual(payload["taskProfile"]["taskId"], "feedback-chat")
+            self.assertEqual(payload["taskProfile"]["qualityTradeoffWeight"], 0.4)
+            self.assertEqual(payload["taskProfile"]["latencyTradeoffWeight"], 3.0)
+            self.assertEqual(payload["taskProfile"]["costTradeoffWeight"], 3.0)
 
     def test_select_feedback_log_adjusts_single_task_ranking(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_model_decisions.py
+++ b/tests/test_model_decisions.py
@@ -283,6 +283,27 @@ class ModelDecisionTests(unittest.TestCase):
         self.assertEqual(situation["weight"], 2.0)
         self.assertEqual(situation["minimumScore"], 40.0)
 
+    def test_decision_output_preserves_tradeoff_weights(self):
+        task = TaskProfile(
+            task_id="tradeoff-chat",
+            required_capabilities={"conversation": 0.8},
+            quality_tradeoff_weight=0.5,
+            latency_tradeoff_weight=2.0,
+            cost_tradeoff_weight=1.5,
+        )
+
+        report = evaluate_model_decisions(sample_models(), [task])
+        payload = report.to_dict()
+        decision = payload["decisions"][0]
+        selected = next(score for score in decision["ranked"] if score["modelId"] == decision["selectedModelId"])
+
+        self.assertEqual(decision["qualityTradeoffWeight"], 0.5)
+        self.assertEqual(decision["latencyTradeoffWeight"], 2.0)
+        self.assertEqual(decision["costTradeoffWeight"], 1.5)
+        self.assertTrue(
+            any("tradeoff weights quality 0.50, latency 2.00, cost 1.50" in reason for reason in selected["reasons"])
+        )
+
     def test_feedback_adjustment_can_promote_eligible_model(self):
         task = TaskProfile(
             task_id="feedback-chat",

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -196,6 +196,82 @@ class ModelRouterTests(unittest.TestCase):
         self.assertEqual(default_selected.model.model_id, "expensive-api")
         self.assertEqual(cheap_selected.model.model_id, "cheap-local")
 
+    def test_default_tradeoff_weights_preserve_selection_and_reasons(self):
+        models = [
+            ModelEndpoint(
+                model_id="fast-local",
+                provider="local",
+                privacy_level="local",
+                context_window_tokens=4096,
+                average_latency_ms=100,
+                capabilities={"conversation": 0.82},
+            ),
+            ModelEndpoint(
+                model_id="slow-remote",
+                provider="api",
+                privacy_level="remote",
+                context_window_tokens=128000,
+                average_latency_ms=5000,
+                input_cost_per_1k=0.004,
+                output_cost_per_1k=0.012,
+                capabilities={"conversation": 0.95},
+            ),
+        ]
+        default_task = TaskProfile(task_id="chat", required_capabilities={"conversation": 0.8})
+        explicit_task = TaskProfile(
+            task_id="chat",
+            required_capabilities={"conversation": 0.8},
+            quality_tradeoff_weight=1.0,
+            latency_tradeoff_weight=1.0,
+            cost_tradeoff_weight=1.0,
+        )
+
+        default_selected = select_model(models, default_task)
+        explicit_selected = select_model(models, explicit_task)
+
+        self.assertEqual(explicit_selected.model.model_id, default_selected.model.model_id)
+        self.assertEqual(explicit_selected.score, default_selected.score)
+        self.assertEqual(explicit_selected.reasons, default_selected.reasons)
+
+    def test_tradeoff_weights_can_change_eligible_ranking(self):
+        models = [
+            ModelEndpoint(
+                model_id="fast-local",
+                provider="local",
+                privacy_level="local",
+                context_window_tokens=4096,
+                average_latency_ms=100,
+                capabilities={"conversation": 0.82},
+            ),
+            ModelEndpoint(
+                model_id="slow-remote",
+                provider="api",
+                privacy_level="remote",
+                context_window_tokens=128000,
+                average_latency_ms=5000,
+                input_cost_per_1k=0.004,
+                output_cost_per_1k=0.012,
+                capabilities={"conversation": 0.95},
+            ),
+        ]
+        default_task = TaskProfile(task_id="chat", required_capabilities={"conversation": 0.8})
+        tradeoff_task = TaskProfile(
+            task_id="chat",
+            required_capabilities={"conversation": 0.8},
+            quality_tradeoff_weight=0.4,
+            latency_tradeoff_weight=3.0,
+            cost_tradeoff_weight=3.0,
+        )
+
+        default_selected = select_model(models, default_task)
+        tradeoff_selected = select_model(models, tradeoff_task)
+
+        self.assertEqual(default_selected.model.model_id, "slow-remote")
+        self.assertEqual(tradeoff_selected.model.model_id, "fast-local")
+        self.assertTrue(
+            any("tradeoff weights quality 0.40, latency 3.00, cost 3.00" in reason for reason in tradeoff_selected.reasons)
+        )
+
     def test_latency_ceiling_blocks_slow_models(self):
         models = [
             ModelEndpoint(
@@ -282,6 +358,27 @@ class ModelRouterTests(unittest.TestCase):
             if score.model.model_id == "local-gemma3-heretic-q4"
         )
 
+        self.assertFalse(local_rank.eligible)
+        self.assertTrue(any("tool support" in blocker for blocker in local_rank.blockers))
+
+    def test_tradeoff_weights_do_not_bypass_hard_blockers(self):
+        task = TaskProfile(
+            task_id="tool-chat",
+            required_capabilities={"conversation": 0.8},
+            require_tools=True,
+            quality_tradeoff_weight=0.2,
+            latency_tradeoff_weight=5.0,
+            cost_tradeoff_weight=5.0,
+        )
+
+        ranked = rank_models(sample_models(), task)
+        local_rank = next(
+            score
+            for score in ranked
+            if score.model.model_id == "local-gemma3-heretic-q4"
+        )
+
+        self.assertEqual(select_model(sample_models(), task).model.model_id, "cli-codex-high")
         self.assertFalse(local_rank.eligible)
         self.assertTrue(any("tool support" in blocker for blocker in local_rank.blockers))
 

--- a/tests/test_task_profiles.py
+++ b/tests/test_task_profiles.py
@@ -17,6 +17,9 @@ class TaskProfileTests(unittest.TestCase):
         self.assertEqual(profile.task_id, "private-chat")
         self.assertEqual(profile.privacy_requirement, "local_only")
         self.assertEqual(profile.required_capabilities["conversation"], 0.8)
+        self.assertEqual(profile.quality_tradeoff_weight, 1.0)
+        self.assertEqual(profile.latency_tradeoff_weight, 1.0)
+        self.assertEqual(profile.cost_tradeoff_weight, 1.0)
 
     def test_load_task_profile_accepts_utf8_bom_file(self):
         payload = {
@@ -49,6 +52,35 @@ class TaskProfileTests(unittest.TestCase):
         self.assertEqual(profile.max_input_cost_per_1k, 0.01)
         self.assertEqual(profile.max_output_cost_per_1k, 0.02)
         self.assertEqual(profile.max_total_cost_per_1k, 0.025)
+
+    def test_parse_task_profile_accepts_tradeoff_weights(self):
+        profile = parse_task_profile(
+            {
+                "schemaVersion": 1,
+                "taskId": "tradeoff-task",
+                "requiredCapabilities": {"conversation": 0.8},
+                "qualityTradeoffWeight": 0.5,
+                "latencyTradeoffWeight": 2.0,
+                "costTradeoffWeight": 1.5,
+            }
+        )
+
+        self.assertEqual(profile.quality_tradeoff_weight, 0.5)
+        self.assertEqual(profile.latency_tradeoff_weight, 2.0)
+        self.assertEqual(profile.cost_tradeoff_weight, 1.5)
+
+    def test_parse_task_profile_rejects_negative_tradeoff_weight(self):
+        with self.assertRaises(TaskProfileError) as error:
+            parse_task_profile(
+                {
+                    "schemaVersion": 1,
+                    "taskId": "broken-tradeoff-task",
+                    "requiredCapabilities": {"conversation": 0.8},
+                    "latencyTradeoffWeight": -1.0,
+                }
+            )
+
+        self.assertIn("latencyTradeoffWeight", str(error.exception))
 
     def test_missing_capabilities_are_rejected(self):
         with self.assertRaises(TaskProfileError) as error:


### PR DESCRIPTION
## Summary
- add task-level quality, latency, and cost tradeoff weights to routing task profiles
- expose additive CLI overrides for the new tradeoff weights
- preserve default routing behavior while allowing otherwise-eligible rankings to shift
- add focused router, task-profile, decision, and CLI regression coverage
- refresh README tracking and add a tradeoff task-profile example

## Verification
- python -m unittest tests.test_model_router tests.test_task_profiles tests.test_model_decisions tests.test_cli
- python -m unittest discover -s tests
- python -m unittest discover -s benchmarks\\openclaw-local-llm
- git diff --check

## Links
- Closes #169