### PR TITLE
Add inline single-task support to recommend CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#171](https://github.com/JKhyro/FURYOKU/issues/171)
+- Current active lane: [#173](https://github.com/JKhyro/FURYOKU/issues/173)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: expose direct CLI flags for latency and total-cost ceilings so the existing constraint-aware runtime is fully usable without requiring a separate JSON task profile.
+- Current follow-on focus: allow `recommend` to accept one inline task with the same constraint fields already supported by `select`, `run`, and `decide`.
 
 ## Product Direction
 

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -262,11 +262,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0 if not report.blocked_tasks else 2
 
     if args.command == "recommend":
-        if args.decision_suite and args.task_profile:
-            parser.error("--decision-suite cannot be combined with --task-profile")
-        decision_input = load_decision_suite(args.decision_suite) if args.decision_suite else tuple(
-            load_task_profile(path) for path in args.task_profile
-        )
+        if args.decision_suite and (args.task_profile or _has_inline_decision_task_args(args)):
+            parser.error("--decision-suite cannot be combined with --task-profile or inline task arguments")
+        if args.decision_suite:
+            decision_input = load_decision_suite(args.decision_suite)
+        elif args.task_profile:
+            decision_input = tuple(load_task_profile(path) for path in args.task_profile)
+        elif _has_inline_decision_task_args(args):
+            decision_input = (_task_from_args(args, parser),)
+        else:
+            decision_input = None
         readiness = _readiness_from_args(args, models)
         feedback, feedback_policy = _feedback_from_args(args, parser)
         routing_policy = _routing_policy_from_args(args)
@@ -510,6 +515,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional task profile to include. Repeat for multiple situations. Defaults to built-in scenarios.",
     )
+    _add_inline_decision_task_args(recommend_parser)
     _add_health_decision_args(recommend_parser, "Run provider readiness checks before recommending models.")
     recommend_parser.add_argument(
         "--feedback-log",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1243,6 +1243,38 @@ class CliTests(unittest.TestCase):
             self.assertIn("outcomeSummary", payload)
             self.assertIn("reportMetadata", persisted)
 
+    def test_recommend_accepts_direct_cli_budget_and_latency_flags(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            write_registry(registry_path)
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "recommend",
+                        "--registry",
+                        str(registry_path),
+                        "--task-id",
+                        "bounded-chat",
+                        "--capability",
+                        "conversation=0.8",
+                        "--max-latency-ms",
+                        "20",
+                        "--max-total-cost-per-1k",
+                        "0.01",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            decision = payload["decisionReport"]["decisions"][0]
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["recommendations"][0]["taskId"], "bounded-chat")
+            self.assertEqual(payload["recommendations"][0]["selectedModel"]["modelId"], "local-echo")
+            self.assertEqual(decision["maxLatencyMs"], 20)
+            self.assertEqual(decision["maxTotalCostPer1k"], 0.01)
+
     def test_example_recommendation_workflow_fixture_is_runnable(self):
         repo_root = Path(__file__).resolve().parents[1]
         registry_path = repo_root / "examples" / "model_registry.example.json"


### PR DESCRIPTION
Add inline single-task support to \\ecommend\\, reuse the existing task constraint fields, add CLI regression coverage, and refresh active-lane tracking. Closes #173.