### PR TITLE
Refresh README active lane anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#173](https://github.com/JKhyro/FURYOKU/issues/173)
+- Current active lane: [#175](https://github.com/JKhyro/FURYOKU/issues/175)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: allow `recommend` to accept one inline task with the same constraint fields already supported by `select`, `run`, and `decide`.
+- Current follow-on focus: add evidence-source filtering so feedback summaries and recommendations can separate routed-run evidence from comparative execution evidence.
 
 ## Product Direction
 


### PR DESCRIPTION
Refresh the README tracking anchor to the new primary runtime issue #175 after closing #173.