### PR TITLE
Add installable package metadata for FURYOKU SDK reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#177](https://github.com/JKhyro/FURYOKU/issues/177)
+- Current active lane: [#180](https://github.com/JKhyro/FURYOKU/issues/180)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: [#73](https://github.com/JKhyro/FURYOKU/issues/73)
 
@@ -22,8 +22,23 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local primary lane: `gemma3-heretic:4b-q4km`
 - Local fallback lane: none configured
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
-- Current architecture direction: multi-model local/CLI/API selection and execution first, with flexible CHARACTER/MOA role composition layered on top.
-- Current follow-on focus: extend evidence-source filtering into live `select`, `run`, and `decide` feedback-backed routing so operators can control which evidence shapes actual model choice.
+- Current architecture direction: multi-model local/CLI/API selection and execution first, then an installable SDK/component surface, with flexible CHARACTER/MOA role composition layered on top.
+- Current follow-on focus: add installable package metadata and a packaged CLI entrypoint so other programs can reuse FURYOKU as a component library before a separate local service/API wrapper is introduced.
+
+## SDK Reuse
+
+FURYOKU is now intended to be consumed both as:
+
+- an importable Python package for direct library/SDK reuse
+- a packaged CLI for process-level integration
+
+Local install examples:
+
+```powershell
+python -m pip install -e .
+furyoku --help
+python -m furyoku --help
+```
 
 ## Product Direction
 

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -1,5 +1,12 @@
 """FURYOKU multi-model routing primitives."""
 
+from importlib.metadata import PackageNotFoundError, version as package_version
+
+try:
+    __version__ = package_version("furyoku")
+except PackageNotFoundError:
+    __version__ = "0.1.0"
+
 from .model_router import (
     CharacterCompositionSelection,
     CharacterPanelSelection,
@@ -119,6 +126,7 @@ from .runtime import (
 from .task_profiles import TaskProfileError, load_task_profile, parse_task_profile
 
 __all__ = [
+    "__version__",
     "ApiProviderAdapter",
     "CharacterCompositionSelection",
     "CharacterPanelSelection",

--- a/furyoku/__main__.py
+++ b/furyoku/__main__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "furyoku"
+version = "0.1.0"
+description = "FURYOKU multi-model routing primitives and CLI."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+furyoku = "furyoku.cli:main"
+
+[tool.setuptools]
+packages = ["furyoku"]
+

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,37 @@
+import subprocess
+import sys
+import tomllib
+import unittest
+from pathlib import Path
+
+import furyoku
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PackagingTests(unittest.TestCase):
+    def test_pyproject_declares_package_metadata_and_cli_entrypoint(self):
+        payload = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["project"]["name"], "furyoku")
+        self.assertEqual(payload["project"]["version"], "0.1.0")
+        self.assertEqual(payload["project"]["scripts"]["furyoku"], "furyoku.cli:main")
+        self.assertEqual(furyoku.__version__, payload["project"]["version"])
+
+    def test_python_module_entrypoint_displays_help(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "furyoku", "--help"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("usage:", result.stdout)
+        self.assertIn("select", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add modern Python packaging metadata via pyproject.toml
- expose the CLI through an installable uryoku console entrypoint and python -m furyoku
- add focused packaging tests and README install guidance

## Verification
- python -m unittest tests.test_packaging tests.test_cli
- python -m unittest discover -s tests
- python -m unittest discover -s benchmarks\\openclaw-local-llm
- powershell -ExecutionPolicy Bypass -File .\\benchmarks\\openclaw-local-llm\\check_compare_truth_fresh.ps1
- isolated editable install in a temporary venv with import furyoku and uryoku --help

Closes #180