### PR TITLE
Add installed smoke coverage for furyoku-service

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import tempfile
 import tomllib
 import unittest
 from pathlib import Path
@@ -45,6 +46,52 @@ class PackagingTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("usage:", result.stdout)
         self.assertIn("--registry", result.stdout)
+
+    def test_editable_install_exposes_service_entrypoint(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            venv_dir = Path(temp_dir) / "venv"
+            subprocess.run(
+                [sys.executable, "-m", "venv", str(venv_dir)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            venv_python = self._venv_python(venv_dir)
+            install_result = subprocess.run(
+                [str(venv_python), "-m", "pip", "install", "-e", str(ROOT)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(install_result.returncode, 0, msg=install_result.stderr)
+
+            service_entrypoint = self._venv_service_entrypoint(venv_dir)
+            self.assertTrue(service_entrypoint.exists(), msg=f"missing installed entrypoint: {service_entrypoint}")
+
+            help_result = subprocess.run(
+                [str(service_entrypoint), "--help"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(help_result.returncode, 0, msg=help_result.stderr)
+            self.assertIn("usage:", help_result.stdout)
+            self.assertIn("--registry", help_result.stdout)
+
+    def _venv_python(self, venv_dir: Path) -> Path:
+        if sys.platform == "win32":
+            return venv_dir / "Scripts" / "python.exe"
+        return venv_dir / "bin" / "python"
+
+    def _venv_service_entrypoint(self, venv_dir: Path) -> Path:
+        if sys.platform == "win32":
+            return venv_dir / "Scripts" / "furyoku-service.exe"
+        return venv_dir / "bin" / "furyoku-service"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add packaging smoke coverage for the installed uryoku-service entrypoint
- create a temporary virtualenv during the test, install the repo editable, and verify the installed wrapper script responds to --help
- keep the delta narrowly scoped to the thin local service wrapper lane

## Verification
- python -m unittest tests.test_packaging
- python -m unittest discover -s tests

Closes #184