### PR TITLE
Add installed inline registry smoke coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: none currently open
+- Current active lane: [#216](https://github.com/JKhyro/FURYOKU/issues/216)
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: none currently open
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: `gemma4-e4b-hauhau-aggressive:q8kp` first when latency or memory pressure rises, then `gemma4-e2b-hauhau-aggressive:q8kp` only for the tightest local fit, but neither is promoted over the current balanced default on this machine yet
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, then reusable component surfaces layered on top, with flexible CHARACTER/MOA role composition downstream rather than bypassing the runtime.
-- Current follow-on focus: no active follow-on is currently open; the most recent wrapper and local-model benchmark lanes are closed and reflected below.
+- Current follow-on focus: installed inline `registry` JSON smoke coverage for `/v1/select` and `/v1/run` so the thin local wrapper proves both request-supplied registry modes end-to-end.
 
 ### Provisional Local Usage Tiers
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -247,6 +247,37 @@ class PackagingTests(unittest.TestCase):
             finally:
                 self._stop_process(process)
 
+    def test_editable_install_exposes_live_select_endpoint_with_inline_registry(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            process, base_url, _registry_path = self._start_installed_service(temp_path)
+            request_registry_path = temp_path / "request-registry.json"
+            self._write_registry_fixture(request_registry_path)
+            registry = json.loads(request_registry_path.read_text(encoding="utf-8"))
+            task = {
+                "schemaVersion": 1,
+                "taskId": "private-chat",
+                "privacyRequirement": "local_only",
+                "requiredCapabilities": {
+                    "conversation": 0.9,
+                },
+            }
+            try:
+                self._wait_for_service_health(process, base_url)
+                payload = self._request_json(
+                    base_url + "/v1/select",
+                    {
+                        "registry": registry,
+                        "task": task,
+                    },
+                )
+
+                self.assertTrue(payload["ok"])
+                self.assertEqual(payload["selection"]["modelId"], "local-echo")
+                self.assertEqual(payload["taskProfile"]["taskId"], "private-chat")
+            finally:
+                self._stop_process(process)
+
     def test_editable_install_exposes_live_run_endpoint_with_registry_path(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -267,6 +298,39 @@ class PackagingTests(unittest.TestCase):
                     base_url + "/v1/run",
                     {
                         "registryPath": str(request_registry_path),
+                        "task": task,
+                        "prompt": "hello",
+                    },
+                )
+
+                self.assertTrue(payload["ok"])
+                self.assertEqual(payload["selection"]["modelId"], "local-echo")
+                self.assertEqual(payload["taskProfile"]["taskId"], "private-chat")
+                self.assertEqual(payload["execution"]["responseText"].strip(), "echo:hello")
+            finally:
+                self._stop_process(process)
+
+    def test_editable_install_exposes_live_run_endpoint_with_inline_registry(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            process, base_url, _registry_path = self._start_installed_service(temp_path)
+            request_registry_path = temp_path / "request-registry.json"
+            self._write_registry_fixture(request_registry_path)
+            registry = json.loads(request_registry_path.read_text(encoding="utf-8"))
+            task = {
+                "schemaVersion": 1,
+                "taskId": "private-chat",
+                "privacyRequirement": "local_only",
+                "requiredCapabilities": {
+                    "conversation": 0.9,
+                },
+            }
+            try:
+                self._wait_for_service_health(process, base_url)
+                payload = self._request_json(
+                    base_url + "/v1/run",
+                    {
+                        "registry": registry,
                         "task": task,
                         "prompt": "hello",
                     },


### PR DESCRIPTION
﻿## Summary
- add installed editable-install smoke coverage for inline request-body `registry` on `/v1/select`
- add installed editable-install smoke coverage for inline request-body `registry` on `/v1/run`
- update README active-lane truth for issue #216 while this wrapper hardening slice is active

## Why
The thin local service contract already supports both `registry` and `registryPath`, but installed-package smoke coverage only proved the default startup registry and `registryPath` flows. This closes the request-body registry coverage gap without widening the wrapper surface.

## Verification
- `python -m unittest tests.test_packaging.PackagingTests.test_editable_install_exposes_live_select_endpoint_with_inline_registry tests.test_packaging.PackagingTests.test_editable_install_exposes_live_run_endpoint_with_inline_registry -q`
- `python -m unittest tests.test_packaging -q`
- `python -m unittest discover -s tests -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`
- `powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1`

Closes #216
