### PR TITLE
Refresh README active lane truth after inline registry smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: [#216](https://github.com/JKhyro/FURYOKU/issues/216)
+- Current active lane: none currently open
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: none currently open
 
@@ -23,7 +23,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local fallback lane: `gemma4-e4b-hauhau-aggressive:q8kp` first when latency or memory pressure rises, then `gemma4-e2b-hauhau-aggressive:q8kp` only for the tightest local fit, but neither is promoted over the current balanced default on this machine yet
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
 - Current architecture direction: multi-model local/CLI/API selection and execution first, then reusable component surfaces layered on top, with flexible CHARACTER/MOA role composition downstream rather than bypassing the runtime.
-- Current follow-on focus: installed inline `registry` JSON smoke coverage for `/v1/select` and `/v1/run` so the thin local wrapper proves both request-supplied registry modes end-to-end.
+- Current follow-on focus: no active follow-on is currently open; the most recent wrapper and local-model benchmark lanes are closed and reflected below.
 
 ### Provisional Local Usage Tiers
 


### PR DESCRIPTION
﻿## Summary
- reset README current active lane after #216 closed
- reset current follow-on focus now that the inline registry smoke lane is merged
- preserve the existing wrapper/model baseline details

## Verification
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`
- `powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1`
- `git diff --check`

Closes #218
