### PR TITLE
Add provider health registry override smokes

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -101,6 +101,47 @@ class PackagingTests(unittest.TestCase):
             finally:
                 self._stop_process(process)
 
+    def test_editable_install_exposes_live_provider_health_endpoint_with_registry_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            process, base_url, _registry_path = self._start_installed_service(temp_path)
+            request_registry_path = temp_path / "request-health-registry.json"
+            self._write_provider_health_override_registry_fixture(request_registry_path)
+            try:
+                self._wait_for_service_health(process, base_url)
+                payload = self._request_json(
+                    base_url + "/v1/health",
+                    {"registryPath": str(request_registry_path)},
+                )
+
+                self.assertTrue(payload["ok"])
+                self.assertEqual(len(payload["providers"]), 1)
+                self.assertEqual(payload["providers"][0]["modelId"], "request-echo")
+                self.assertTrue(payload["providers"][0]["ready"])
+            finally:
+                self._stop_process(process)
+
+    def test_editable_install_exposes_live_provider_health_endpoint_with_inline_registry(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            process, base_url, _registry_path = self._start_installed_service(temp_path)
+            request_registry_path = temp_path / "request-health-registry.json"
+            self._write_provider_health_override_registry_fixture(request_registry_path)
+            registry = json.loads(request_registry_path.read_text(encoding="utf-8"))
+            try:
+                self._wait_for_service_health(process, base_url)
+                payload = self._request_json(
+                    base_url + "/v1/health",
+                    {"registry": registry},
+                )
+
+                self.assertTrue(payload["ok"])
+                self.assertEqual(len(payload["providers"]), 1)
+                self.assertEqual(payload["providers"][0]["modelId"], "request-echo")
+                self.assertTrue(payload["providers"][0]["ready"])
+            finally:
+                self._stop_process(process)
+
     def test_editable_install_exposes_live_select_and_run_endpoints(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -437,6 +478,33 @@ class PackagingTests(unittest.TestCase):
                             "capabilities": {
                                 "conversation": 0.8,
                                 "coding": 0.98,
+                            },
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def _write_provider_health_override_registry_fixture(self, registry_path: Path) -> None:
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "models": [
+                        {
+                            "modelId": "request-echo",
+                            "provider": "local",
+                            "privacyLevel": "local",
+                            "contextWindowTokens": 4096,
+                            "averageLatencyMs": 10,
+                            "invocation": [
+                                sys.executable,
+                                "-c",
+                                "import sys; print('echo:' + sys.stdin.read())",
+                            ],
+                            "capabilities": {
+                                "conversation": 0.95,
                             },
                         },
                     ],


### PR DESCRIPTION
﻿## Summary
- add installed `/v1/health` smoke coverage for a valid request-time `registryPath`
- add installed `/v1/health` smoke coverage for a valid inline request-body `registry`
- use a distinct one-model request registry so the response proves the override path is used instead of the startup default registry

## Why
The thin local service uses the same registry resolver for `health`, `select`, and `run`. Select/run already had installed valid override coverage for `registryPath` and inline `registry`; provider health only had default-registry success plus invalid-registry error coverage.

## Verification
- `python -m unittest tests.test_packaging.PackagingTests.test_editable_install_exposes_live_provider_health_endpoint_with_registry_path tests.test_packaging.PackagingTests.test_editable_install_exposes_live_provider_health_endpoint_with_inline_registry -q`
- `python -m unittest tests.test_packaging -q`
- `python -m unittest discover -s tests -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`
- `powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1`
- `git diff --check`

Closes #220
