### PR TITLE
Add registry override conflict smoke

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -220,6 +220,33 @@ class PackagingTests(unittest.TestCase):
             finally:
                 self._stop_process(process)
 
+    def test_editable_install_rejects_provider_health_registry_override_conflict(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            process, base_url, _registry_path = self._start_installed_service(temp_path)
+            request_registry_path = temp_path / "request-health-registry.json"
+            self._write_provider_health_override_registry_fixture(request_registry_path)
+            registry = json.loads(request_registry_path.read_text(encoding="utf-8"))
+            try:
+                self._wait_for_service_health(process, base_url)
+                error = self._request_http_error(
+                    base_url + "/v1/health",
+                    {
+                        "registry": registry,
+                        "registryPath": str(request_registry_path),
+                    },
+                )
+
+                self.assertEqual(error["status"], 400)
+                self.assertFalse(error["payload"]["ok"])
+                self.assertEqual(error["payload"]["error"]["type"], "ServiceRequestError")
+                self.assertIn(
+                    "provide only one of registry or registryPath",
+                    error["payload"]["error"]["message"],
+                )
+            finally:
+                self._stop_process(process)
+
     def test_editable_install_exposes_live_select_endpoint_with_task_path(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)


### PR DESCRIPTION
﻿## Summary
- add an installed `/v1/health` smoke for conflicting registry override inputs
- assert the thin service returns a stable JSON `ServiceRequestError` when both `registry` and `registryPath` are supplied
- keep the wrapper surface unchanged while covering the ambiguous-input branch of the shared registry resolver

## Why
The thin local service rejects simultaneous `registry` and `registryPath`, but installed smoke coverage had only proven valid override modes and invalid registry type. This closes the ambiguity/error-path gap through `/v1/health`, the smallest endpoint that exercises the shared resolver.

## Verification
- `python -m unittest tests.test_packaging.PackagingTests.test_editable_install_rejects_provider_health_registry_override_conflict -q`
- `python -m unittest tests.test_packaging -q`
- `python -m unittest discover -s tests -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`
- `powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1`
- `git diff --check`

Closes #222
