### PR TITLE
Add run missing prompt smoke

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -205,6 +205,32 @@ class PackagingTests(unittest.TestCase):
             finally:
                 self._stop_process(process)
 
+    def test_editable_install_rejects_run_missing_prompt_with_valid_task(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            process, base_url, _registry_path = self._start_installed_service(temp_path)
+            task = {
+                "schemaVersion": 1,
+                "taskId": "private-chat",
+                "privacyRequirement": "local_only",
+                "requiredCapabilities": {
+                    "conversation": 0.9,
+                },
+            }
+            try:
+                self._wait_for_service_health(process, base_url)
+                error = self._request_http_error(base_url + "/v1/run", {"task": task})
+
+                self.assertEqual(error["status"], 400)
+                self.assertFalse(error["payload"]["ok"])
+                self.assertEqual(error["payload"]["error"]["type"], "ServiceRequestError")
+                self.assertIn(
+                    "prompt is required and must be a non-empty string",
+                    error["payload"]["error"]["message"],
+                )
+            finally:
+                self._stop_process(process)
+
     def test_editable_install_exposes_service_error_payload_for_invalid_provider_health(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)


### PR DESCRIPTION
﻿## Summary
- add an installed `/v1/run` error-path smoke for a valid task with omitted `prompt`
- assert the thin service returns a stable JSON `ServiceRequestError` for the run-specific prompt requirement
- keep the wrapper surface unchanged while covering the endpoint-specific validation branch

## Why
The existing installed invalid-run smoke used an empty payload, which fails at missing task before reaching `/v1/run`'s prompt validator. This test pins the documented `prompt` requirement directly.

## Verification
- `python -m unittest tests.test_packaging.PackagingTests.test_editable_install_rejects_run_missing_prompt_with_valid_task -q`
- `python -m unittest tests.test_packaging -q`
- `python -m unittest discover -s tests -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`
- `powershell -ExecutionPolicy Bypass -File .\benchmarks\openclaw-local-llm\check_compare_truth_fresh.ps1`
- `git diff --check`

Closes #224
