### PR TITLE
Document Hermes runtime migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter ratification: [#1](https://github.com/JKhyro/FURYOKU/issues/1)
 - First execution wave closure: [#2](https://github.com/JKhyro/FURYOKU/issues/2)
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
-- Current active lane: none currently open
+- Current active lane: [#230](https://github.com/JKhyro/FURYOKU/issues/230) Hermes Agent becomes the FURYOKU runtime base
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Current support lane: none currently open
 
@@ -22,8 +22,9 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Local primary lane: `gemma4-e4b-ultra-heretic:q8_0` as the provisional balanced local default on limited hardware
 - Local fallback lane: `gemma4-e4b-hauhau-aggressive:q8kp` first when latency or memory pressure rises, then `gemma4-e2b-hauhau-aggressive:q8kp` only for the tightest local fit, but neither is promoted over the current balanced default on this machine yet
 - Strong remote continuation: `minimax-portal/MiniMax-M2.7` then `openai-codex/gpt-5.4`
-- Current architecture direction: multi-model local/CLI/API selection and execution first, then reusable component surfaces layered on top, with flexible CHARACTER/MOA role composition downstream rather than bypassing the runtime.
-- Current follow-on focus: no active follow-on is currently open; the most recent wrapper and local-model benchmark lanes are closed and reflected below.
+- Current architecture direction: Hermes-derived FURYOKU runtime first, with the existing multi-model local/CLI/API selection, benchmark truth, provider health, feedback, and service-wrapper assets preserved as reusable FURYOKU components.
+- Current follow-on focus: migrate the 7-Symbiote swarm onto the Hermes-derived FURYOKU base quickly, then inventory and port only the OpenClaw features that improve the new runtime without carrying forward OpenClaw's coordination failure modes.
+- Migration plan: [Hermes-derived FURYOKU migration](docs/hermes-furyoku-migration.md)
 
 ### Provisional Local Usage Tiers
 
@@ -79,14 +80,17 @@ Initial wrapper contract:
 
 ## Product Direction
 
-FURYOKU's currently known job is to help the wider system choose and use the right LLM for the situation. This is the current implementation horizon, not the final long-term definition of the project.
+FURYOKU's current runtime direction is now Hermes-derived FURYOKU: Hermes Agent becomes the base architecture for operating the 7-Symbiote swarm, and OpenClaw becomes a feature/source integration lane rather than the controlling runtime.
+
+The existing FURYOKU model-selection package remains part of the runtime spine. Its job is still to help the wider system choose and use the right LLM for each situation, but it now serves the Hermes-derived swarm runtime instead of assuming OpenClaw is the primary host.
 
 Scope guard:
 
 - Do not treat benchmark truth or CI support as the project purpose.
-- Keep the primary execution lane on the multi-model local/CLI/API decision system unless the user explicitly redirects.
+- Keep the primary execution lane on Hermes-derived FURYOKU for swarm operation, with the multi-model local/CLI/API decision system retained as reusable routing infrastructure.
+- Treat OpenClaw as a source of features to inventory and selectively port, not as the default runtime base.
 - Treat flexible CHARACTER/MOA support as important downstream product work, not discarded scope.
-- Sequence the work deliberately: make the multi-model decision/runtime layer functional first, then use it to power flexible CHARACTER/MOA arrays such as one-role tertiary Symbiotes and larger primary-plus-secondary role compositions.
+- Sequence the work deliberately: make the Hermes/FURYOKU 7-Symbiote control loop functional first, then layer broader CHARACTER/MOA arrays and OpenClaw feature harvests onto the stable runtime.
 - Treat benchmark and CI work as supporting evidence and safety infrastructure.
 
 - Register multiple model endpoints: local models, command-line/CLI models, and remote API models.
@@ -185,7 +189,7 @@ python -m furyoku.cli character-run --registry .\examples\model_registry.example
 
 ## Benchmark Evidence Lane
 
-- Local OpenClaw model benchmark: [`benchmarks/openclaw-local-llm`](benchmarks/openclaw-local-llm)
+- Historical OpenClaw local-model benchmark, retained as FURYOKU routing evidence during the Hermes migration: [`benchmarks/openclaw-local-llm`](benchmarks/openclaw-local-llm)
 - Current deployed-baseline manifest: [2026-04-13 approved-ready current-baseline manifest](benchmarks/openclaw-local-llm/results/2026-04-13-approved-ready-current-baseline.json)
 - Current deployed-baseline evidence: [2026-04-13 approved-ready compare summary](benchmarks/openclaw-local-llm/results/2026-04-13-approved-ready-compare-summary.md)
 - Current blocked-roster evidence: [2026-04-13 approved blocked-roster probe](benchmarks/openclaw-local-llm/results/2026-04-13-approved-blocked-roster-probe.json)

--- a/docs/hermes-furyoku-migration.md
+++ b/docs/hermes-furyoku-migration.md
@@ -20,6 +20,21 @@ Hermes Agent is the preferred base because its design is expected to fit multi-a
 - The fastest useful milestone is a functional 7-Symbiote Hermes/FURYOKU control loop, not broad feature parity.
 - Current local model restrictions remain in force; do not use local models outside the approved roster.
 
+## Hermes Source Inventory
+
+The first read-only source check against `JKhyro/HERMES-AGENT` shows the mirror is a Python package named `hermes-agent` at version `0.6.0` with these likely migration-relevant surfaces:
+
+- `run_agent.py`: packaged `hermes-agent` entrypoint and likely primary agent loop surface.
+- `cli.py` and `hermes_cli`: interactive CLI and operator command surface.
+- `agent/`: provider adapters, prompt construction, credential pools, model metadata, smart routing, skills, context compression, trajectory capture, and pricing/usage support.
+- `acp_adapter/` and `acp_registry/`: Agent Client Protocol integration surfaces that may be useful for clean process boundaries.
+- `model_tools.py`, `toolsets.py`, and `toolset_distributions.py`: model/tool capability surfaces that should be compared with FURYOKU's current provider registry and task requirements.
+- `mcp_serve.py`: MCP serving surface for future tool interoperability.
+- `batch_runner.py`, `mini_swe_runner.py`, `trajectory_compressor.py`, and `rl_cli.py`: research/evaluation/training-adjacent surfaces that are useful later, but not the first swarm-stability target.
+- `scripts/install.ps1` and `scripts/install.cmd`: Windows install helpers exist, but upstream README still says native Windows is not supported and recommends WSL2.
+
+Immediate risk: this project is currently operating from Windows, while upstream Hermes is explicitly WSL2-oriented for Windows users. The first implementation slice should therefore prove either a WSL2-hosted Hermes/FURYOKU bridge or a narrowly adapted local process bridge before assuming direct native Windows operation.
+
 ## Fast Migration Order
 
 1. Confirm the local Hermes Agent source path, launch command, config path, and current runnable state.
@@ -40,7 +55,7 @@ The first code-bearing migration issue should be opened after the local Hermes p
 
 - input: one Symbiote task envelope with role, prompt, and required model capabilities
 - routing: FURYOKU model selection and provider health checks choose an eligible lane
-- runtime handoff: Hermes/FURYOKU receives exactly one bounded task
+- runtime handoff: Hermes/FURYOKU receives exactly one bounded task through the confirmed WSL2 or local process boundary
 - output: structured result with selected model, execution status, latency, and recoverable error details
 
 The first slice should not attempt full OpenClaw parity, long-running memory, remote deployment, or cross-product CORTEX/VECTOR/SYNAPSE integration.

--- a/docs/hermes-furyoku-migration.md
+++ b/docs/hermes-furyoku-migration.md
@@ -1,0 +1,53 @@
+# Hermes-Derived FURYOKU Migration
+
+## Decision
+
+FURYOKU now moves to a Hermes Agent-derived runtime base. Hermes carries the FURYOKU runtime name going forward, and OpenClaw is demoted from controlling runtime to feature/source integration lane.
+
+This decision is tracked in [issue #230](https://github.com/JKhyro/FURYOKU/issues/230).
+
+## Why This Changes
+
+The current 7-Symbiote swarm is exposing coordination failures that are larger than model selection. The hard problems are identity stability, task ownership, swarm arbitration, state boundaries, backpressure, and recovery from confused or duplicate agent behavior.
+
+Hermes Agent is the preferred base because its design is expected to fit multi-agent operation better than OpenClaw's current shape. The migration should preserve proven FURYOKU assets while putting a stricter runtime spine under the swarm.
+
+## Runtime Stance
+
+- Hermes-derived FURYOKU is the active base for the 7-Symbiote swarm.
+- OpenClaw is a feature inventory source, not the default runtime host.
+- Existing FURYOKU local/CLI/API model routing, provider health, feedback, benchmark truth, and service-wrapper contracts remain reusable components.
+- The fastest useful milestone is a functional 7-Symbiote Hermes/FURYOKU control loop, not broad feature parity.
+- Current local model restrictions remain in force; do not use local models outside the approved roster.
+
+## Fast Migration Order
+
+1. Confirm the local Hermes Agent source path, launch command, config path, and current runnable state.
+2. Define the minimal Hermes/FURYOKU swarm contract for seven Symbiotes: identity, role, allowed model lane, state boundary, task queue ownership, and stop/retry behavior.
+3. Build or adapt the first local bridge so FURYOKU can route selected model/provider calls into the Hermes runtime without bypassing provider health and benchmark-truth evidence.
+4. Run a one-Symbiote smoke, then a three-Symbiote coordination smoke, then the full seven-Symbiote smoke.
+5. Inventory OpenClaw features and port only the pieces that improve Hermes/FURYOKU without recreating the coordination failure modes.
+
+## OpenClaw Feature Harvest Rules
+
+- Keep: useful UI affordances, local model configuration lessons, benchmark prompts, operator ergonomics, and any proven adapter contracts.
+- Re-evaluate: agent conversation flow, shared state, task routing, and fallback behavior before porting.
+- Avoid: uncontrolled cross-talk, unclear task ownership, hidden shared mutable state, or any pattern that makes seven agents compete for the same work.
+
+## First Implementation Slice
+
+The first code-bearing migration issue should be opened after the local Hermes path is confirmed. It should target the smallest possible bridge:
+
+- input: one Symbiote task envelope with role, prompt, and required model capabilities
+- routing: FURYOKU model selection and provider health checks choose an eligible lane
+- runtime handoff: Hermes/FURYOKU receives exactly one bounded task
+- output: structured result with selected model, execution status, latency, and recoverable error details
+
+The first slice should not attempt full OpenClaw parity, long-running memory, remote deployment, or cross-product CORTEX/VECTOR/SYNAPSE integration.
+
+## Verification Plan
+
+- Documentation truth: README and this plan identify Hermes-derived FURYOKU as the active direction.
+- GitHub truth: issue #230 stays In Progress until the first executable bridge issue is opened.
+- Local smoke: one-Symbiote route can run without swarm contention.
+- Scale smoke: seven Symbiotes can hold distinct identities and task boundaries without duplicate execution.


### PR DESCRIPTION
## Summary
- record #230 as the active Hermes-derived FURYOKU runtime migration lane
- update README product direction so Hermes Agent is the runtime base and OpenClaw is a feature/source lane
- add a migration plan focused on getting the 7-Symbiote swarm functional before broad feature parity

## Verification
- `git diff --check` (only existing LF-to-CRLF warnings)
- `python -m unittest tests.test_model_registry tests.test_character_profiles -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`

## Notes
- Full `python -m unittest discover -s tests -q` was attempted but timed out after roughly 124 seconds in this environment before completion.
- No code migration from Hermes or OpenClaw is included in this first bootstrap PR.