### PR TITLE
Document Hermes launch bridge smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Charter feedback discussion: [#3](https://github.com/JKhyro/FURYOKU/discussions/3)
 - Current active lane: [#230](https://github.com/JKhyro/FURYOKU/issues/230) Hermes Agent becomes the FURYOKU runtime base
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
-- Current support lane: none currently open
+- Current support lane: [#232](https://github.com/JKhyro/FURYOKU/issues/232) prepare Hermes/FURYOKU launch bridge and one-Symbiote smoke
 
 ## Current Baseline
 
@@ -25,6 +25,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Current architecture direction: Hermes-derived FURYOKU runtime first, with the existing multi-model local/CLI/API selection, benchmark truth, provider health, feedback, and service-wrapper assets preserved as reusable FURYOKU components.
 - Current follow-on focus: migrate the 7-Symbiote swarm onto the Hermes-derived FURYOKU base quickly, then inventory and port only the OpenClaw features that improve the new runtime without carrying forward OpenClaw's coordination failure modes.
 - Migration plan: [Hermes-derived FURYOKU migration](docs/hermes-furyoku-migration.md)
+- Launch bridge plan: [Hermes/FURYOKU launch bridge](docs/hermes-launch-bridge.md)
 
 ### Provisional Local Usage Tiers
 

--- a/docs/hermes-launch-bridge.md
+++ b/docs/hermes-launch-bridge.md
@@ -1,0 +1,93 @@
+# Hermes/FURYOKU Launch Bridge
+
+## Purpose
+
+This document tracks issue [#232](https://github.com/JKhyro/FURYOKU/issues/232): prepare the first executable Hermes-derived FURYOKU launch bridge and one-Symbiote smoke.
+
+Parent migration lane: [#230](https://github.com/JKhyro/FURYOKU/issues/230).
+
+## Current Host Check
+
+The current Windows host does not yet expose a usable Linux WSL2 distro for upstream Hermes:
+
+```powershell
+wsl -l -v
+```
+
+Observed result in this thread: only `docker-desktop` was listed, and it was stopped.
+
+Upstream Hermes says native Windows is not supported and recommends WSL2 for Windows users. That makes WSL2 launch readiness the first practical gate before we claim the Hermes runtime is runnable on this machine.
+
+## Operator Handoff If WSL2 Is Missing
+
+Run this from an elevated or normal PowerShell session as appropriate for the host policy:
+
+```powershell
+wsl --install -d Ubuntu
+wsl -d Ubuntu -- uname -a
+```
+
+Once Ubuntu is available, prepare a read-only Hermes source checkout inside WSL:
+
+```bash
+mkdir -p ~/src
+cd ~/src
+git clone https://github.com/JKhyro/HERMES-AGENT.git
+cd HERMES-AGENT
+python3 --version
+```
+
+Do not migrate secrets yet. First prove the source checkout, Python version, and launch command.
+
+## One-Symbiote Smoke Contract
+
+The first bridge smoke should pass exactly one bounded task from FURYOKU into Hermes-derived FURYOKU:
+
+```json
+{
+  "schemaVersion": 1,
+  "symbioteId": "symbiote-01",
+  "role": "primary",
+  "task": {
+    "taskId": "hermes.bridge.one-symbiote",
+    "requiredCapabilities": {
+      "conversation": 0.8,
+      "instruction_following": 0.8
+    },
+    "privacyRequirement": "local_preferred"
+  },
+  "prompt": "Reply with one short sentence confirming the Hermes/FURYOKU bridge received this task.",
+  "routing": {
+    "checkHealth": true,
+    "fallback": true,
+    "maxAttempts": 2
+  }
+}
+```
+
+Expected output contract:
+
+- selected model/provider from FURYOKU routing evidence
+- Hermes/FURYOKU handoff status
+- execution success or recoverable error
+- latency or timing detail when available
+- no duplicate Symbiote execution
+
+## Implementation Boundary
+
+- FURYOKU owns model selection, provider health, benchmark evidence, task profile loading, and result shape.
+- Hermes-derived FURYOKU owns the agent runtime loop and Symbiote task execution.
+- OpenClaw remains a carryover inventory source only.
+- The first smoke must not start all seven Symbiotes.
+- The first smoke must not import broad Hermes source into the FURYOKU package.
+
+## Next Code Slice
+
+After WSL2 and the Hermes source path are confirmed, add the smallest bridge scaffold:
+
+1. A FURYOKU bridge module or CLI command that serializes the one-Symbiote task envelope.
+2. A configurable Hermes launch command/path.
+3. A dry-run mode that validates the envelope without invoking Hermes.
+4. A live mode that invokes one Hermes/FURYOKU task and captures structured output.
+
+The scale path is one Symbiote first, then three, then seven.


### PR DESCRIPTION
## Summary
- mark #232 as the active support lane under the Hermes-derived FURYOKU migration
- document the current WSL2 launch gate for upstream Hermes on this Windows host
- define the first one-Symbiote bridge smoke envelope and output contract
- capture the operator handoff commands needed when no usable WSL2 Linux distro is present

## Verification
- `git diff --check` (only LF-to-CRLF warnings)
- `python -m unittest tests.test_model_registry tests.test_character_profiles -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`

## Notes
This PR does not attempt to install WSL2, clone Hermes, or run Hermes. It records the exact launch gate and smoke contract so the first code bridge can proceed without pretending native Windows Hermes execution is already available.