### PR TITLE
[codex] Add Hermes bridge dry-run scaffold

### DIFF
--- a/docs/hermes-launch-bridge.md
+++ b/docs/hermes-launch-bridge.md
@@ -91,3 +91,15 @@ After WSL2 and the Hermes source path are confirmed, add the smallest bridge sca
 4. A live mode that invokes one Hermes/FURYOKU task and captures structured output.
 
 The scale path is one Symbiote first, then three, then seven.
+
+## Dry-Run Scaffold
+
+The first FURYOKU-side scaffold is intentionally dry-run only. It can be exercised before Ubuntu WSL2 is available because it does not invoke Hermes:
+
+```powershell
+python -m furyoku.cli hermes-bridge --registry .\examples\model_registry.example.json --envelope .\examples\hermes_bridge_one_symbiote.example.json --dry-run
+```
+
+The dry-run validates that the input describes exactly one Symbiote task, derives a duplicate-prevention execution key from `symbioteId`, `role`, and `taskId`, runs FURYOKU model selection with optional provider health evidence from the envelope, and emits the structured handoff result expected by the live bridge.
+
+Live mode remains blocked until a usable Ubuntu WSL2 distro and Hermes source path are confirmed. The scaffold must not be widened into multi-Symbiote execution until the one-Symbiote live handoff is proven.

--- a/examples/hermes_bridge_one_symbiote.example.json
+++ b/examples/hermes_bridge_one_symbiote.example.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "symbioteId": "symbiote-01",
+  "role": "primary",
+  "task": {
+    "taskId": "hermes.bridge.one-symbiote",
+    "requiredCapabilities": {
+      "conversation": 0.8,
+      "instruction_following": 0.8
+    },
+    "privacyRequirement": "local_preferred"
+  },
+  "prompt": "Reply with one short sentence confirming the Hermes/FURYOKU bridge received this task.",
+  "routing": {
+    "checkHealth": true,
+    "fallback": true,
+    "maxAttempts": 2
+  }
+}

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version as package_version
 
 try:
-    __version__ = package_version("furyoku")
+    __version__ = package_version("furyoku") or "0.1.0"
 except PackageNotFoundError:
     __version__ = "0.1.0"
 

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -77,6 +77,14 @@ from .provider_health import (
     check_provider_health,
     check_provider_health_many,
 )
+from .hermes_bridge import (
+    HermesBridgeDryRunResult,
+    HermesBridgeEnvelope,
+    HermesBridgeError,
+    HermesBridgeRoutingOptions,
+    dry_run_hermes_bridge,
+    load_hermes_bridge_envelope,
+)
 from .outcome_feedback import (
     DecisionOutcomeRecord,
     FeedbackAdjustmentInput,
@@ -147,6 +155,10 @@ __all__ = [
     "FeedbackAdjustmentPolicy",
     "FeedbackAdjustmentPolicyInput",
     "FeedbackPolicyMetadata",
+    "HermesBridgeDryRunResult",
+    "HermesBridgeEnvelope",
+    "HermesBridgeError",
+    "HermesBridgeRoutingOptions",
     "ModelCoverage",
     "ModelDecisionAggregate",
     "ModelDecisionError",
@@ -194,6 +206,7 @@ __all__ = [
     "default_character_role_tasks",
     "default_decision_scenarios",
     "default_provider_adapters",
+    "dry_run_hermes_bridge",
     "evaluate_model_decisions",
     "execute_model",
     "compare_decision_situation_executions",
@@ -215,6 +228,7 @@ __all__ = [
     "load_decision_suite",
     "load_decision_outcomes",
     "load_feedback_adjustment_policy",
+    "load_hermes_bridge_envelope",
     "load_task_profile",
     "outcome_feedback_source",
     "parse_feedback_adjustment_policy",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -29,6 +29,7 @@ from .outcome_feedback import (
 )
 from .provider_health import ProviderHealthCheckRequest, ProviderHealthCheckResult, check_provider_health_many
 from .provider_adapters import ProviderExecutionRequest, ProviderExecutionResult
+from .hermes_bridge import HermesBridgeError, dry_run_hermes_bridge, load_hermes_bridge_envelope
 from .runtime import (
     CharacterRoleExecutionResult,
     ComparativeExecutionBatchResult,
@@ -239,6 +240,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         _write_json({"ok": all(result.ready for result in results), "providers": [_health_to_dict(result) for result in results]})
         return 0 if all(result.ready for result in results) else 2
+
+    if args.command == "hermes-bridge":
+        if not args.dry_run:
+            parser.error("hermes-bridge currently supports --dry-run only until the WSL2 live handoff is available")
+        try:
+            envelope = load_hermes_bridge_envelope(args.envelope)
+            result = dry_run_hermes_bridge(
+                models,
+                envelope,
+                seen_execution_keys=args.seen_execution_key,
+                routing_policy=_routing_policy_from_args(args),
+            )
+        except HermesBridgeError as exc:
+            parser.error(str(exc))
+        _write_json(result.to_dict(), output_path=args.output)
+        return 0 if result.ok else 2
 
     if args.command == "decide":
         if args.decision_suite and (args.task_profile or _has_inline_decision_task_args(args)):
@@ -474,6 +491,25 @@ def _build_parser() -> argparse.ArgumentParser:
     health_parser.add_argument("--probe", action="store_true", help="Run a lightweight probe instead of only checking configuration.")
     health_parser.add_argument("--probe-prompt", default="", help="Prompt text used when --probe is set.")
     health_parser.add_argument("--timeout-seconds", type=float, default=5.0, help="Health probe timeout in seconds.")
+    bridge_parser = subparsers.add_parser(
+        "hermes-bridge",
+        help="Validate and route a one-Symbiote Hermes/FURYOKU handoff envelope.",
+    )
+    bridge_parser.add_argument("--registry", required=True, type=Path, help="Path to a FURYOKU model registry JSON file.")
+    bridge_parser.add_argument("--envelope", required=True, type=Path, help="Path to a one-Symbiote bridge envelope JSON file.")
+    bridge_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate, route, and shape the handoff result without invoking Hermes.",
+    )
+    bridge_parser.add_argument(
+        "--seen-execution-key",
+        action="append",
+        default=[],
+        help="Execution key already claimed by this handoff cycle. Repeat to prevent duplicate Symbiote execution.",
+    )
+    _add_routing_policy_arg(bridge_parser)
+    bridge_parser.add_argument("--output", type=Path, help="Optional path to persist the JSON dry-run handoff report.")
     decide_parser = subparsers.add_parser(
         "decide",
         help="Evaluate local, CLI, and API models across multiple decision situations.",

--- a/furyoku/hermes_bridge.py
+++ b/furyoku/hermes_bridge.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .model_decisions import ModelDecisionReport, ReadinessEvidenceInput, evaluate_model_decisions
+from .model_router import ModelEndpoint, ModelScore, RoutingScorePolicyInput, TaskProfile
+from .provider_health import (
+    CommandResolver,
+    ProviderHealthCheckRequest,
+    ProviderHealthCheckResult,
+    check_provider_health_many,
+)
+from .task_profiles import parse_task_profile
+
+
+class HermesBridgeError(ValueError):
+    """Raised when a Hermes/FURYOKU bridge envelope is malformed."""
+
+
+@dataclass(frozen=True)
+class HermesBridgeRoutingOptions:
+    """Routing controls embedded in a one-Symbiote bridge envelope."""
+
+    check_health: bool = False
+    fallback: bool = False
+    max_attempts: int | None = None
+    health_probe: bool = False
+    health_probe_prompt: str = ""
+    health_timeout_seconds: float | None = 5.0
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None, *, source: str = "<memory>") -> "HermesBridgeRoutingOptions":
+        if payload is None:
+            return cls()
+        if not isinstance(payload, Mapping):
+            raise HermesBridgeError(f"{source}: routing must be a JSON object")
+        max_attempts = _optional_positive_int(payload.get("maxAttempts", payload.get("max_attempts")), field_name="maxAttempts", source=source)
+        fallback = bool(payload.get("fallback", False))
+        if max_attempts is not None and not fallback:
+            raise HermesBridgeError(f"{source}: routing.maxAttempts requires routing.fallback=true")
+        return cls(
+            check_health=bool(payload.get("checkHealth", payload.get("check_health", False))),
+            fallback=fallback,
+            max_attempts=max_attempts,
+            health_probe=bool(payload.get("healthProbe", payload.get("health_probe", False))),
+            health_probe_prompt=str(payload.get("healthProbePrompt", payload.get("health_probe_prompt", "")) or ""),
+            health_timeout_seconds=_optional_positive_float(
+                payload.get("healthTimeoutSeconds", payload.get("health_timeout_seconds", 5.0)),
+                field_name="healthTimeoutSeconds",
+                source=source,
+            ),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "checkHealth": self.check_health,
+            "fallback": self.fallback,
+            "maxAttempts": self.max_attempts,
+            "healthProbe": self.health_probe,
+            "healthProbePrompt": self.health_probe_prompt,
+            "healthTimeoutSeconds": self.health_timeout_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class HermesBridgeEnvelope:
+    """One bounded Symbiote task envelope prepared for Hermes/FURYOKU handoff."""
+
+    schema_version: int
+    symbiote_id: str
+    role: str
+    task: TaskProfile
+    prompt: str
+    routing: HermesBridgeRoutingOptions = HermesBridgeRoutingOptions()
+
+    @property
+    def execution_key(self) -> str:
+        return f"{self.symbiote_id}:{self.role}:{self.task.task_id}"
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any], *, source: str = "<memory>") -> "HermesBridgeEnvelope":
+        if not isinstance(payload, Mapping):
+            raise HermesBridgeError(f"{source}: bridge envelope must be a JSON object")
+        if payload.get("symbiotes") is not None:
+            raise HermesBridgeError(f"{source}: bridge envelope must describe exactly one Symbiote, not a symbiotes array")
+        if payload.get("tasks") is not None:
+            raise HermesBridgeError(f"{source}: bridge envelope must describe exactly one task, not a tasks array")
+
+        schema_version = int(payload.get("schemaVersion", payload.get("schema_version", 1)) or 1)
+        if schema_version != 1:
+            raise HermesBridgeError(f"{source}: unsupported bridge envelope schemaVersion {schema_version!r}")
+
+        symbiote_id = _required_string(payload, "symbioteId", "symbiote_id", source=source)
+        role = _required_string(payload, "role", source=source)
+        prompt = _required_string(payload, "prompt", source=source)
+
+        raw_task = payload.get("task")
+        if not isinstance(raw_task, Mapping):
+            raise HermesBridgeError(f"{source}: task must be a JSON object")
+        try:
+            task = parse_task_profile(_normalize_bridge_task_payload(raw_task), source=f"{source}:task")
+        except ValueError as exc:
+            raise HermesBridgeError(str(exc)) from exc
+
+        return cls(
+            schema_version=schema_version,
+            symbiote_id=symbiote_id,
+            role=role,
+            task=task,
+            prompt=prompt,
+            routing=HermesBridgeRoutingOptions.from_dict(payload.get("routing"), source=f"{source}:routing"),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "schemaVersion": self.schema_version,
+            "symbioteId": self.symbiote_id,
+            "role": self.role,
+            "task": self.task.to_dict(),
+            "prompt": self.prompt,
+            "routing": self.routing.to_dict(),
+            "executionKey": self.execution_key,
+        }
+
+
+@dataclass(frozen=True)
+class HermesBridgeDryRunResult:
+    """Structured dry-run result for the first Hermes/FURYOKU one-Symbiote bridge."""
+
+    envelope: HermesBridgeEnvelope
+    handoff_status: str
+    execution_status: str
+    selected: ModelScore | None
+    report: ModelDecisionReport | None
+    readiness: tuple[ProviderHealthCheckResult, ...]
+    elapsed_ms: float
+    duplicate: bool = False
+    error: Mapping[str, Any] | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.handoff_status == "dry-run-ready" and self.selected is not None and self.selected.eligible
+
+    def to_dict(self) -> dict:
+        return {
+            "schemaVersion": 1,
+            "ok": self.ok,
+            "mode": "dry_run",
+            "bridge": "hermes-furyoku",
+            "envelope": self.envelope.to_dict(),
+            "selectedModel": _score_to_dict(self.selected) if self.selected is not None else None,
+            "handoff": {
+                "status": self.handoff_status,
+                "dryRun": True,
+                "runtime": "Hermes/FURYOKU",
+                "boundary": "FURYOKU routing and envelope validation only; Hermes runtime was not invoked",
+            },
+            "execution": {
+                "status": self.execution_status,
+                "started": False,
+                "elapsedMs": round(self.elapsed_ms, 3),
+            },
+            "duplicateGuard": {
+                "enabled": True,
+                "executionKey": self.envelope.execution_key,
+                "duplicate": self.duplicate,
+            },
+            "readiness": [_health_to_dict(result) for result in self.readiness],
+            "decisionReport": self.report.to_dict() if self.report is not None else None,
+            "error": dict(self.error) if self.error is not None else None,
+        }
+
+
+def load_hermes_bridge_envelope(path: str | Path) -> HermesBridgeEnvelope:
+    envelope_path = Path(path)
+    with envelope_path.open("r", encoding="utf-8-sig") as handle:
+        payload = json.load(handle)
+    return HermesBridgeEnvelope.from_dict(payload, source=str(envelope_path))
+
+
+def dry_run_hermes_bridge(
+    models: list[ModelEndpoint],
+    envelope: HermesBridgeEnvelope,
+    *,
+    seen_execution_keys: Iterable[str] | None = None,
+    readiness: ReadinessEvidenceInput | None = None,
+    routing_policy: RoutingScorePolicyInput | None = None,
+    command_resolver: CommandResolver | None = None,
+) -> HermesBridgeDryRunResult:
+    """Validate one Symbiote handoff and select its FURYOKU model without invoking Hermes."""
+
+    started = time.perf_counter()
+    seen_keys = set(seen_execution_keys or ())
+    if envelope.execution_key in seen_keys:
+        return HermesBridgeDryRunResult(
+            envelope=envelope,
+            handoff_status="duplicate-prevented",
+            execution_status="skipped",
+            selected=None,
+            report=None,
+            readiness=(),
+            elapsed_ms=_elapsed_ms(started),
+            duplicate=True,
+            error={
+                "recoverable": True,
+                "code": "duplicate_execution_key",
+                "message": f"duplicate Symbiote execution prevented for {envelope.execution_key}",
+            },
+        )
+
+    resolved_readiness = readiness
+    readiness_results = _provider_health_results(readiness)
+    if envelope.routing.check_health and readiness is None:
+        readiness_results = tuple(
+            check_provider_health_many(
+                models,
+                ProviderHealthCheckRequest(
+                    probe=envelope.routing.health_probe,
+                    probe_prompt=envelope.routing.health_probe_prompt,
+                    timeout_seconds=envelope.routing.health_timeout_seconds,
+                ),
+                command_resolver=command_resolver,
+            )
+        )
+        resolved_readiness = readiness_results
+
+    report = evaluate_model_decisions(
+        models,
+        [envelope.task],
+        readiness=resolved_readiness or None,
+        routing_policy=routing_policy,
+    )
+    selected = report.selected_for(envelope.task.task_id)
+    if selected is None:
+        return HermesBridgeDryRunResult(
+            envelope=envelope,
+            handoff_status="routing-blocked",
+            execution_status="not-started",
+            selected=None,
+            report=report,
+            readiness=readiness_results,
+            elapsed_ms=_elapsed_ms(started),
+            error={
+                "recoverable": True,
+                "code": "no_eligible_model",
+                "message": _blocked_summary(report, envelope.task.task_id),
+            },
+        )
+
+    return HermesBridgeDryRunResult(
+        envelope=envelope,
+        handoff_status="dry-run-ready",
+        execution_status="not-started",
+        selected=selected,
+        report=report,
+        readiness=readiness_results,
+        elapsed_ms=_elapsed_ms(started),
+    )
+
+
+def _provider_health_results(readiness: ReadinessEvidenceInput | None) -> tuple[ProviderHealthCheckResult, ...]:
+    if readiness is None:
+        return ()
+    values = readiness.values() if isinstance(readiness, Mapping) else readiness
+    return tuple(item for item in values if isinstance(item, ProviderHealthCheckResult))
+
+
+def _blocked_summary(report: ModelDecisionReport, task_id: str) -> str:
+    decision = report.situations[task_id]
+    if not decision.blockers:
+        return f"no eligible model satisfied task {task_id}"
+    return "; ".join(
+        f"{model_id}: {', '.join(blockers)}"
+        for model_id, blockers in decision.blockers.items()
+    )
+
+
+def _normalize_bridge_task_payload(payload: Mapping[str, Any]) -> dict:
+    normalized = dict(payload)
+    privacy = normalized.get("privacyRequirement", normalized.get("privacy_requirement"))
+    if privacy == "local_preferred":
+        normalized["privacyRequirement"] = "prefer_local"
+    return normalized
+
+
+def _score_to_dict(selection: ModelScore) -> dict:
+    payload = {
+        "modelId": selection.model.model_id,
+        "provider": selection.model.provider,
+        "score": selection.score,
+        "eligible": selection.eligible,
+        "averageLatencyMs": selection.model.average_latency_ms,
+        "reasons": list(selection.reasons),
+        "blockers": list(selection.blockers),
+    }
+    total_cost_per_1k = selection.model.input_cost_per_1k + selection.model.output_cost_per_1k
+    if selection.model.input_cost_per_1k > 0.0:
+        payload["inputCostPer1k"] = selection.model.input_cost_per_1k
+    if selection.model.output_cost_per_1k > 0.0:
+        payload["outputCostPer1k"] = selection.model.output_cost_per_1k
+    if total_cost_per_1k > 0.0:
+        payload["totalCostPer1k"] = round(total_cost_per_1k, 6)
+    return payload
+
+
+def _health_to_dict(result: ProviderHealthCheckResult) -> dict:
+    payload = {
+        "modelId": result.model_id,
+        "provider": result.provider,
+        "status": result.status,
+        "ready": result.ready,
+        "reason": result.reason,
+        "command": result.command,
+        "resolvedCommand": result.resolved_command,
+    }
+    if result.execution is not None:
+        payload["execution"] = {
+            "status": result.execution.status,
+            "elapsedMs": result.execution.elapsed_ms,
+            "exitCode": result.execution.exit_code,
+            "stderr": result.execution.stderr,
+            "error": result.execution.error,
+            "timedOut": result.execution.timed_out,
+        }
+    return payload
+
+
+def _required_string(payload: Mapping[str, Any], *keys: str, source: str) -> str:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    display_key = keys[0]
+    raise HermesBridgeError(f"{source}: {display_key} is required")
+
+
+def _optional_positive_int(value: Any, *, field_name: str, source: str) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise HermesBridgeError(f"{source}: {field_name} must be an integer") from exc
+    if parsed < 1:
+        raise HermesBridgeError(f"{source}: {field_name} must be at least 1")
+    return parsed
+
+
+def _optional_positive_float(value: Any, *, field_name: str, source: str) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise HermesBridgeError(f"{source}: {field_name} must be numeric") from exc
+    if parsed <= 0.0:
+        raise HermesBridgeError(f"{source}: {field_name} must be greater than 0")
+    return parsed
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.perf_counter() - started) * 1000.0

--- a/tests/test_hermes_bridge.py
+++ b/tests/test_hermes_bridge.py
@@ -1,0 +1,247 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+
+from furyoku import (
+    HermesBridgeEnvelope,
+    HermesBridgeError,
+    ModelEndpoint,
+    dry_run_hermes_bridge,
+    load_hermes_bridge_envelope,
+)
+
+
+def local_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="local-echo",
+        provider="local",
+        privacy_level="local",
+        context_window_tokens=4096,
+        average_latency_ms=10,
+        invocation=(sys.executable, "-c", "print('ready')"),
+        capabilities={"conversation": 0.95, "instruction_following": 0.9},
+    )
+
+
+def cli_endpoint() -> ModelEndpoint:
+    return ModelEndpoint(
+        model_id="cli-fallback",
+        provider="cli",
+        privacy_level="remote",
+        context_window_tokens=128000,
+        average_latency_ms=20,
+        invocation=("missing-cli-command",),
+        capabilities={"conversation": 0.9, "instruction_following": 0.9},
+    )
+
+
+def envelope_payload() -> dict:
+    return {
+        "schemaVersion": 1,
+        "symbioteId": "symbiote-01",
+        "role": "primary",
+        "task": {
+            "taskId": "hermes.bridge.one-symbiote",
+            "requiredCapabilities": {
+                "conversation": 0.8,
+                "instruction_following": 0.8,
+            },
+            "privacyRequirement": "prefer_local",
+        },
+        "prompt": "Confirm the dry-run bridge.",
+        "routing": {
+            "checkHealth": True,
+            "fallback": True,
+            "maxAttempts": 2,
+        },
+    }
+
+
+class HermesBridgeTests(unittest.TestCase):
+    def test_loads_one_symbiote_envelope(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "envelope.json"
+            path.write_text(json.dumps(envelope_payload()), encoding="utf-8")
+
+            envelope = load_hermes_bridge_envelope(path)
+
+        self.assertEqual(envelope.symbiote_id, "symbiote-01")
+        self.assertEqual(envelope.role, "primary")
+        self.assertEqual(envelope.task.task_id, "hermes.bridge.one-symbiote")
+        self.assertEqual(envelope.execution_key, "symbiote-01:primary:hermes.bridge.one-symbiote")
+        self.assertTrue(envelope.routing.check_health)
+        self.assertEqual(envelope.routing.max_attempts, 2)
+
+    def test_rejects_multi_symbiote_payload(self):
+        payload = envelope_payload()
+        payload["symbiotes"] = [{"symbioteId": "symbiote-01"}, {"symbioteId": "symbiote-02"}]
+
+        with self.assertRaises(HermesBridgeError) as error:
+            HermesBridgeEnvelope.from_dict(payload)
+
+        self.assertIn("exactly one Symbiote", str(error.exception))
+
+    def test_dry_run_selects_model_and_does_not_start_execution(self):
+        envelope = HermesBridgeEnvelope.from_dict(envelope_payload())
+
+        result = dry_run_hermes_bridge(
+            [local_endpoint(), cli_endpoint()],
+            envelope,
+            command_resolver=lambda command: command if command == sys.executable else None,
+        )
+        payload = result.to_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(payload["selectedModel"]["modelId"], "local-echo")
+        self.assertEqual(payload["handoff"]["status"], "dry-run-ready")
+        self.assertEqual(payload["execution"]["status"], "not-started")
+        self.assertFalse(payload["execution"]["started"])
+        self.assertEqual(payload["duplicateGuard"]["executionKey"], envelope.execution_key)
+        self.assertTrue(any(item["modelId"] == "local-echo" and item["ready"] for item in payload["readiness"]))
+
+    def test_dry_run_prevents_duplicate_execution_key(self):
+        envelope = HermesBridgeEnvelope.from_dict(envelope_payload())
+
+        result = dry_run_hermes_bridge(
+            [local_endpoint()],
+            envelope,
+            seen_execution_keys=[envelope.execution_key],
+        )
+        payload = result.to_dict()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(payload["handoff"]["status"], "duplicate-prevented")
+        self.assertEqual(payload["execution"]["status"], "skipped")
+        self.assertTrue(payload["duplicateGuard"]["duplicate"])
+        self.assertEqual(payload["error"]["code"], "duplicate_execution_key")
+
+    def test_dry_run_reports_recoverable_routing_blocker(self):
+        envelope = HermesBridgeEnvelope.from_dict(envelope_payload())
+        weak_model = ModelEndpoint(
+            model_id="weak-local",
+            provider="local",
+            privacy_level="local",
+            context_window_tokens=4096,
+            average_latency_ms=10,
+            invocation=(sys.executable,),
+            capabilities={"conversation": 0.2},
+        )
+
+        result = dry_run_hermes_bridge([weak_model], envelope)
+        payload = result.to_dict()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(payload["handoff"]["status"], "routing-blocked")
+        self.assertEqual(payload["error"]["code"], "no_eligible_model")
+        self.assertIn("instruction_following", payload["error"]["message"])
+
+
+class HermesBridgeCliTests(unittest.TestCase):
+    def test_cli_dry_run_outputs_bridge_report(self):
+        from furyoku.cli import main
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            registry_path = temp_path / "models.json"
+            envelope_path = temp_path / "envelope.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "models": [
+                            {
+                                "modelId": "local-echo",
+                                "provider": "local",
+                                "privacyLevel": "local",
+                                "contextWindowTokens": 4096,
+                                "averageLatencyMs": 10,
+                                "invocation": [
+                                    sys.executable,
+                                    "-c",
+                                    "import sys; print(sys.stdin.read())",
+                                ],
+                                "capabilities": {
+                                    "conversation": 0.95,
+                                    "instruction_following": 0.9,
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            envelope_path.write_text(json.dumps(envelope_payload()), encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "furyoku.cli",
+                    "hermes-bridge",
+                    "--registry",
+                    str(registry_path),
+                    "--envelope",
+                    str(envelope_path),
+                    "--dry-run",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["bridge"], "hermes-furyoku")
+        self.assertEqual(payload["selectedModel"]["modelId"], "local-echo")
+        self.assertEqual(payload["handoff"]["status"], "dry-run-ready")
+
+    def test_cli_requires_dry_run_flag(self):
+        from furyoku.cli import main
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            registry_path = temp_path / "models.json"
+            envelope_path = temp_path / "envelope.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "models": [
+                            {
+                                "modelId": "local-echo",
+                                "provider": "local",
+                                "privacyLevel": "local",
+                                "contextWindowTokens": 4096,
+                                "averageLatencyMs": 10,
+                                "invocation": [sys.executable],
+                                "capabilities": {
+                                    "conversation": 0.95,
+                                    "instruction_following": 0.9,
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            envelope_path.write_text(json.dumps(envelope_payload()), encoding="utf-8")
+
+            with redirect_stderr(StringIO()):
+                with self.assertRaises(SystemExit) as error:
+                    main(
+                        [
+                            "hermes-bridge",
+                            "--registry",
+                            str(registry_path),
+                            "--envelope",
+                            str(envelope_path),
+                        ]
+                    )
+
+        self.assertEqual(error.exception.code, 2)


### PR DESCRIPTION
## Summary

- Adds a `furyoku.hermes_bridge` dry-run scaffold for the #232 one-Symbiote Hermes/FURYOKU bridge.
- Validates exactly one Symbiote task envelope, normalizes the handoff `local_preferred` privacy alias to FURYOKU's `prefer_local`, and derives a duplicate-prevention execution key.
- Routes through existing FURYOKU model decision/provider-health evidence without invoking Hermes, then emits a structured dry-run handoff result with selected model, execution status, timing, readiness, and recoverable error details.
- Adds `python -m furyoku.cli hermes-bridge --dry-run`, a reusable example envelope, focused tests, and launch-bridge docs.

## Scope

This stays inside `JKhyro/FURYOKU` issue #232. It does not mutate `JKhyro/HERMES-AGENT`, does not start live Hermes, and does not start multi-Symbiote execution.

## Verification

Passed:

- `python -m unittest tests.test_hermes_bridge tests.test_cli tests.test_runtime -q`
- `python -m furyoku.cli hermes-bridge --registry .\examples\model_registry.example.json --envelope .\examples\hermes_bridge_one_symbiote.example.json --dry-run`
- `git diff --check` (only existing LF-to-CRLF warnings)
- `python -m unittest tests.test_model_registry tests.test_character_profiles -q`
- `python -m unittest benchmarks.openclaw-local-llm.test_benchmark_contract_report -q`

Blocked:

- `python -m unittest discover -s tests -q` could not complete because the host C: drive reported `0` bytes free and tests failed while creating temp files/venvs with `OSError: [Errno 28] No space left on device`.

## Remaining Blocker

Live Hermes execution remains blocked until Ubuntu WSL2 is available (`wsl -d Ubuntu -- uname -a` currently fails with `WSL_E_DISTRO_NOT_FOUND`).