### PR TITLE
Add Hermes bridge live handoff mode

### DIFF
--- a/docs/hermes-launch-bridge.md
+++ b/docs/hermes-launch-bridge.md
@@ -8,13 +8,14 @@ Parent migration lane: [#230](https://github.com/JKhyro/FURYOKU/issues/230).
 
 ## Current Host Check
 
-The current Windows host does not yet expose a usable Linux WSL2 distro for upstream Hermes:
+The Windows host now exposes an Ubuntu WSL2 distro for the Hermes launch path:
 
 ```powershell
 wsl -l -v
+wsl -d Ubuntu -- uname -a
 ```
 
-Observed result in this thread: only `docker-desktop` was listed, and it was stopped.
+Observed result in this thread: `wsl --install -d Ubuntu` timed out after registering Ubuntu, the first `uname` probe returned `Wsl/Service/E_UNEXPECTED`, then `wsl --shutdown` cleared the WSL service state and `wsl -d Ubuntu -- uname -a` succeeded.
 
 Upstream Hermes says native Windows is not supported and recommends WSL2 for Windows users. That makes WSL2 launch readiness the first practical gate before we claim the Hermes runtime is runnable on this machine.
 
@@ -102,4 +103,20 @@ python -m furyoku.cli hermes-bridge --registry .\examples\model_registry.example
 
 The dry-run validates that the input describes exactly one Symbiote task, derives a duplicate-prevention execution key from `symbioteId`, `role`, and `taskId`, runs FURYOKU model selection with optional provider health evidence from the envelope, and emits the structured handoff result expected by the live bridge.
 
-Live mode remains blocked until a usable Ubuntu WSL2 distro and Hermes source path are confirmed. The scaffold must not be widened into multi-Symbiote execution until the one-Symbiote live handoff is proven.
+## Live Process-Boundary Scaffold
+
+Live mode invokes exactly one configured handoff command after the same one-Symbiote envelope validation, duplicate guard, and FURYOKU model routing used by dry-run mode. The validated handoff payload is written to the command on stdin, and the command's stdout/stderr, exit code, timing, and recoverable errors are captured in the structured bridge report.
+
+This command proves the Windows-to-WSL process boundary without claiming a full Hermes agent execution. The example runtime reads the bridge payload from stdin and echoes the execution key plus selected model evidence:
+
+```powershell
+python -m furyoku.cli hermes-bridge `
+  --registry .\examples\model_registry.example.json `
+  --envelope .\examples\hermes_bridge_one_symbiote.example.json `
+  --timeout-seconds 10 `
+  --handoff-command wsl -d Ubuntu python3 <furyoku-repo-wsl-path>/examples/hermes_bridge_echo_runtime.py
+```
+
+On the current handoff host, `<furyoku-repo-wsl-path>` resolved to `/mnt/c/Users/Allan/OneDrive/Documents/FURYOKU-local-model-roster-refresh`.
+
+To execute Hermes itself, replace the handoff command with the confirmed Hermes/FURYOKU launch command from the read-only WSL checkout. The scaffold must not be widened into multi-Symbiote execution until the one-Symbiote live handoff is proven.

--- a/examples/hermes_bridge_echo_runtime.py
+++ b/examples/hermes_bridge_echo_runtime.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    envelope = payload.get("envelope", {})
+    selected = payload.get("selectedModel") or {}
+    json.dump(
+        {
+            "status": "ok",
+            "bridge": payload.get("bridge"),
+            "mode": payload.get("mode"),
+            "executionKey": envelope.get("executionKey"),
+            "symbioteId": envelope.get("symbioteId"),
+            "role": envelope.get("role"),
+            "taskId": (envelope.get("task") or {}).get("taskId"),
+            "selectedModelId": selected.get("modelId"),
+            "selectedProvider": selected.get("provider"),
+        },
+        sys.stdout,
+        sort_keys=True,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -81,8 +81,10 @@ from .hermes_bridge import (
     HermesBridgeDryRunResult,
     HermesBridgeEnvelope,
     HermesBridgeError,
+    HermesBridgeLiveResult,
     HermesBridgeRoutingOptions,
     dry_run_hermes_bridge,
+    live_run_hermes_bridge,
     load_hermes_bridge_envelope,
 )
 from .outcome_feedback import (
@@ -158,6 +160,7 @@ __all__ = [
     "HermesBridgeDryRunResult",
     "HermesBridgeEnvelope",
     "HermesBridgeError",
+    "HermesBridgeLiveResult",
     "HermesBridgeRoutingOptions",
     "ModelCoverage",
     "ModelDecisionAggregate",
@@ -207,6 +210,7 @@ __all__ = [
     "default_decision_scenarios",
     "default_provider_adapters",
     "dry_run_hermes_bridge",
+    "live_run_hermes_bridge",
     "evaluate_model_decisions",
     "execute_model",
     "compare_decision_situation_executions",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -29,7 +29,7 @@ from .outcome_feedback import (
 )
 from .provider_health import ProviderHealthCheckRequest, ProviderHealthCheckResult, check_provider_health_many
 from .provider_adapters import ProviderExecutionRequest, ProviderExecutionResult
-from .hermes_bridge import HermesBridgeError, dry_run_hermes_bridge, load_hermes_bridge_envelope
+from .hermes_bridge import HermesBridgeError, dry_run_hermes_bridge, live_run_hermes_bridge, load_hermes_bridge_envelope
 from .runtime import (
     CharacterRoleExecutionResult,
     ComparativeExecutionBatchResult,
@@ -242,16 +242,29 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0 if all(result.ready for result in results) else 2
 
     if args.command == "hermes-bridge":
-        if not args.dry_run:
-            parser.error("hermes-bridge currently supports --dry-run only until the WSL2 live handoff is available")
+        if args.dry_run and args.handoff_command:
+            parser.error("--dry-run cannot be combined with --handoff-command")
+        if not args.dry_run and not args.handoff_command:
+            parser.error("hermes-bridge live mode requires --handoff-command, or use --dry-run")
         try:
             envelope = load_hermes_bridge_envelope(args.envelope)
-            result = dry_run_hermes_bridge(
-                models,
-                envelope,
-                seen_execution_keys=args.seen_execution_key,
-                routing_policy=_routing_policy_from_args(args),
-            )
+            if args.dry_run:
+                result = dry_run_hermes_bridge(
+                    models,
+                    envelope,
+                    seen_execution_keys=args.seen_execution_key,
+                    routing_policy=_routing_policy_from_args(args),
+                )
+            else:
+                result = live_run_hermes_bridge(
+                    models,
+                    envelope,
+                    handoff_command=tuple(args.handoff_command),
+                    seen_execution_keys=args.seen_execution_key,
+                    routing_policy=_routing_policy_from_args(args),
+                    timeout_seconds=args.timeout_seconds,
+                    cwd=args.handoff_cwd,
+                )
         except HermesBridgeError as exc:
             parser.error(str(exc))
         _write_json(result.to_dict(), output_path=args.output)
@@ -503,13 +516,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Validate, route, and shape the handoff result without invoking Hermes.",
     )
     bridge_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=60.0,
+        help="Live handoff process timeout in seconds.",
+    )
+    bridge_parser.add_argument(
+        "--handoff-cwd",
+        type=Path,
+        help="Optional working directory for the live handoff process.",
+    )
+    bridge_parser.add_argument(
         "--seen-execution-key",
         action="append",
         default=[],
         help="Execution key already claimed by this handoff cycle. Repeat to prevent duplicate Symbiote execution.",
     )
     _add_routing_policy_arg(bridge_parser)
-    bridge_parser.add_argument("--output", type=Path, help="Optional path to persist the JSON dry-run handoff report.")
+    bridge_parser.add_argument("--output", type=Path, help="Optional path to persist the JSON bridge handoff report.")
+    bridge_parser.add_argument(
+        "--handoff-command",
+        nargs=argparse.REMAINDER,
+        help="Live handoff command to invoke. Must be the final CLI option; the validated payload is sent on stdin.",
+    )
     decide_parser = subparsers.add_parser(
         "decide",
         help="Evaluate local, CLI, and API models across multiple decision situations.",

--- a/furyoku/hermes_bridge.py
+++ b/furyoku/hermes_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -175,6 +176,57 @@ class HermesBridgeDryRunResult:
         }
 
 
+@dataclass(frozen=True)
+class HermesBridgeLiveResult:
+    """Structured result for a one-Symbiote Hermes/FURYOKU process-boundary handoff."""
+
+    dry_run: HermesBridgeDryRunResult
+    handoff_command: tuple[str, ...]
+    handoff_status: str
+    execution_status: str
+    elapsed_ms: float
+    started: bool = False
+    exit_code: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+    runtime_payload: Mapping[str, Any] | str | None = None
+    error: Mapping[str, Any] | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.dry_run.ok and self.handoff_status == "completed" and self.execution_status == "succeeded"
+
+    def to_dict(self) -> dict:
+        payload = self.dry_run.to_dict()
+        payload.update(
+            {
+                "ok": self.ok,
+                "mode": "live",
+                "selectedModel": _score_to_dict(self.dry_run.selected) if self.dry_run.selected is not None else None,
+                "handoff": {
+                    "status": self.handoff_status,
+                    "dryRun": False,
+                    "runtime": "Hermes/FURYOKU",
+                    "boundary": "FURYOKU routing and envelope validation with one external process-boundary handoff",
+                    "command": list(self.handoff_command),
+                },
+                "execution": {
+                    "status": self.execution_status,
+                    "started": self.started,
+                    "elapsedMs": round(self.elapsed_ms, 3),
+                    "exitCode": self.exit_code,
+                    "stdout": self.stdout,
+                    "stderr": self.stderr,
+                    "timedOut": self.timed_out,
+                    "runtimePayload": self.runtime_payload,
+                },
+                "error": dict(self.error) if self.error is not None else None,
+            }
+        )
+        return payload
+
+
 def load_hermes_bridge_envelope(path: str | Path) -> HermesBridgeEnvelope:
     envelope_path = Path(path)
     with envelope_path.open("r", encoding="utf-8-sig") as handle:
@@ -262,6 +314,128 @@ def dry_run_hermes_bridge(
     )
 
 
+def live_run_hermes_bridge(
+    models: list[ModelEndpoint],
+    envelope: HermesBridgeEnvelope,
+    *,
+    handoff_command: tuple[str, ...],
+    seen_execution_keys: Iterable[str] | None = None,
+    readiness: ReadinessEvidenceInput | None = None,
+    routing_policy: RoutingScorePolicyInput | None = None,
+    command_resolver: CommandResolver | None = None,
+    timeout_seconds: float | None = 60.0,
+    cwd: str | Path | None = None,
+) -> HermesBridgeLiveResult:
+    """Route exactly one Symbiote task, then hand it to one configured Hermes process boundary."""
+
+    started = time.perf_counter()
+    if not handoff_command:
+        raise HermesBridgeError("live Hermes bridge requires a non-empty handoff command")
+
+    dry_run = dry_run_hermes_bridge(
+        models,
+        envelope,
+        seen_execution_keys=seen_execution_keys,
+        readiness=readiness,
+        routing_policy=routing_policy,
+        command_resolver=command_resolver,
+    )
+    if not dry_run.ok:
+        return HermesBridgeLiveResult(
+            dry_run=dry_run,
+            handoff_command=tuple(handoff_command),
+            handoff_status=dry_run.handoff_status,
+            execution_status=dry_run.execution_status,
+            elapsed_ms=_elapsed_ms(started),
+            error=dry_run.error,
+        )
+
+    handoff_payload = {
+        "schemaVersion": 1,
+        "bridge": "hermes-furyoku",
+        "mode": "live",
+        "envelope": envelope.to_dict(),
+        "selectedModel": _score_to_dict(dry_run.selected) if dry_run.selected is not None else None,
+        "decisionReport": dry_run.report.to_dict() if dry_run.report is not None else None,
+        "readiness": [_health_to_dict(result) for result in dry_run.readiness],
+    }
+    try:
+        completed = subprocess.run(
+            list(handoff_command),
+            input=json.dumps(handoff_payload),
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            timeout=timeout_seconds,
+            cwd=str(cwd) if cwd is not None else None,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return HermesBridgeLiveResult(
+            dry_run=dry_run,
+            handoff_command=tuple(handoff_command),
+            handoff_status="timeout",
+            execution_status="timeout",
+            elapsed_ms=_elapsed_ms(started),
+            started=True,
+            stdout=_coerce_text(exc.stdout),
+            stderr=_coerce_text(exc.stderr),
+            timed_out=True,
+            error={
+                "recoverable": True,
+                "code": "handoff_timeout",
+                "message": f"Hermes/FURYOKU handoff timed out after {exc.timeout} seconds",
+            },
+        )
+    except OSError as exc:
+        return HermesBridgeLiveResult(
+            dry_run=dry_run,
+            handoff_command=tuple(handoff_command),
+            handoff_status="failed",
+            execution_status="error",
+            elapsed_ms=_elapsed_ms(started),
+            error={
+                "recoverable": True,
+                "code": "handoff_launch_failed",
+                "message": str(exc),
+            },
+        )
+
+    runtime_payload = _parse_runtime_payload(completed.stdout)
+    if completed.returncode != 0:
+        return HermesBridgeLiveResult(
+            dry_run=dry_run,
+            handoff_command=tuple(handoff_command),
+            handoff_status="failed",
+            execution_status="error",
+            elapsed_ms=_elapsed_ms(started),
+            started=True,
+            exit_code=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+            runtime_payload=runtime_payload,
+            error={
+                "recoverable": True,
+                "code": "handoff_process_failed",
+                "message": f"Hermes/FURYOKU handoff exited with code {completed.returncode}",
+            },
+        )
+
+    return HermesBridgeLiveResult(
+        dry_run=dry_run,
+        handoff_command=tuple(handoff_command),
+        handoff_status="completed",
+        execution_status="succeeded",
+        elapsed_ms=_elapsed_ms(started),
+        started=True,
+        exit_code=completed.returncode,
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+        runtime_payload=runtime_payload,
+    )
+
+
 def _provider_health_results(readiness: ReadinessEvidenceInput | None) -> tuple[ProviderHealthCheckResult, ...]:
     if readiness is None:
         return ()
@@ -327,6 +501,27 @@ def _health_to_dict(result: ProviderHealthCheckResult) -> dict:
             "timedOut": result.execution.timed_out,
         }
     return payload
+
+
+def _parse_runtime_payload(stdout: str) -> Mapping[str, Any] | str | None:
+    stripped = stdout.strip()
+    if not stripped:
+        return None
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return stripped
+    if isinstance(payload, Mapping):
+        return payload
+    return stripped
+
+
+def _coerce_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
 def _required_string(payload: Mapping[str, Any], *keys: str, source: str) -> str:

--- a/tests/test_hermes_bridge.py
+++ b/tests/test_hermes_bridge.py
@@ -12,6 +12,7 @@ from furyoku import (
     HermesBridgeError,
     ModelEndpoint,
     dry_run_hermes_bridge,
+    live_run_hermes_bridge,
     load_hermes_bridge_envelope,
 )
 
@@ -140,6 +141,57 @@ class HermesBridgeTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "no_eligible_model")
         self.assertIn("instruction_following", payload["error"]["message"])
 
+    def test_live_run_invokes_one_handoff_command(self):
+        envelope = HermesBridgeEnvelope.from_dict(envelope_payload())
+        result = live_run_hermes_bridge(
+            [local_endpoint()],
+            envelope,
+            handoff_command=(
+                sys.executable,
+                "-c",
+                "import json, sys; payload=json.load(sys.stdin); print(json.dumps({'status':'ok','executionKey':payload['envelope']['executionKey']}))",
+            ),
+        )
+        payload = result.to_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(payload["mode"], "live")
+        self.assertEqual(payload["handoff"]["status"], "completed")
+        self.assertEqual(payload["execution"]["status"], "succeeded")
+        self.assertTrue(payload["execution"]["started"])
+        self.assertEqual(payload["execution"]["runtimePayload"]["executionKey"], envelope.execution_key)
+
+    def test_live_run_does_not_start_duplicate_execution_key(self):
+        envelope = HermesBridgeEnvelope.from_dict(envelope_payload())
+        result = live_run_hermes_bridge(
+            [local_endpoint()],
+            envelope,
+            handoff_command=("missing-live-handoff-command",),
+            seen_execution_keys=[envelope.execution_key],
+        )
+        payload = result.to_dict()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(payload["handoff"]["status"], "duplicate-prevented")
+        self.assertEqual(payload["execution"]["status"], "skipped")
+        self.assertFalse(payload["execution"]["started"])
+        self.assertTrue(payload["duplicateGuard"]["duplicate"])
+
+    def test_live_run_reports_recoverable_handoff_failure(self):
+        envelope = HermesBridgeEnvelope.from_dict(envelope_payload())
+        result = live_run_hermes_bridge(
+            [local_endpoint()],
+            envelope,
+            handoff_command=(sys.executable, "-c", "import sys; sys.stderr.write('bad runtime'); sys.exit(3)"),
+        )
+        payload = result.to_dict()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(payload["handoff"]["status"], "failed")
+        self.assertEqual(payload["execution"]["status"], "error")
+        self.assertEqual(payload["execution"]["exitCode"], 3)
+        self.assertEqual(payload["error"]["code"], "handoff_process_failed")
+
 
 class HermesBridgeCliTests(unittest.TestCase):
     def test_cli_dry_run_outputs_bridge_report(self):
@@ -245,3 +297,61 @@ class HermesBridgeCliTests(unittest.TestCase):
                     )
 
         self.assertEqual(error.exception.code, 2)
+
+    def test_cli_live_mode_invokes_handoff_command(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            registry_path = temp_path / "models.json"
+            envelope_path = temp_path / "envelope.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "models": [
+                            {
+                                "modelId": "local-echo",
+                                "provider": "local",
+                                "privacyLevel": "local",
+                                "contextWindowTokens": 4096,
+                                "averageLatencyMs": 10,
+                                "invocation": [sys.executable, "-c", "print('ready')"],
+                                "capabilities": {
+                                    "conversation": 0.95,
+                                    "instruction_following": 0.9,
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            envelope_path.write_text(json.dumps(envelope_payload()), encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "furyoku.cli",
+                    "hermes-bridge",
+                    "--registry",
+                    str(registry_path),
+                    "--envelope",
+                    str(envelope_path),
+                    "--timeout-seconds",
+                    "5",
+                    "--handoff-command",
+                    sys.executable,
+                    "-c",
+                    "import json, sys; payload=json.load(sys.stdin); print(json.dumps({'received':payload['envelope']['executionKey']}))",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["mode"], "live")
+        self.assertEqual(payload["handoff"]["status"], "completed")
+        self.assertEqual(payload["execution"]["runtimePayload"]["received"], "symbiote-01:primary:hermes.bridge.one-symbiote")


### PR DESCRIPTION
## Summary

- Adds live mode for `furyoku.cli hermes-bridge` using one configured process-boundary handoff command.
- Sends the validated one-Symbiote bridge payload to the handoff command on stdin and captures stdout/stderr, exit code, timing, parsed runtime payload, timeout, and recoverable errors.
- Preserves FURYOKU routing/provider-health ownership and duplicate execution prevention before any live handoff starts.
- Adds a tiny WSL echo runtime example that reads the bridge payload and returns the execution key plus selected model/provider evidence.
- Updates the #232 launch bridge doc with the Ubuntu WSL recovery and live process-boundary smoke command.

## Validation

- `wsl --install -d Ubuntu` timed out but registered Ubuntu.
- `wsl -d Ubuntu -- uname -a` initially failed with `Wsl/Service/E_UNEXPECTED`; `wsl --shutdown` recovered it.
- `wsl -d Ubuntu -- uname -a` now succeeds.
- `wsl -d Ubuntu -- python3 --version` reports Python 3.12.3.
- `python -m unittest tests.test_hermes_bridge -q` passed.
- `python -m unittest tests.test_hermes_bridge tests.test_cli tests.test_runtime -q` passed.
- `git diff --check` passed with only LF-to-CRLF warnings.
- Live bridge WSL payload smoke passed:
  `python -m furyoku.cli hermes-bridge --registry .\examples\model_registry.example.json --envelope .\examples\hermes_bridge_one_symbiote.example.json --timeout-seconds 10 --handoff-command wsl -d Ubuntu python3 /mnt/c/Users/Allan/OneDrive/Documents/FURYOKU-local-model-roster-refresh/examples/hermes_bridge_echo_runtime.py`

## Notes

This PR proves the Windows-to-Ubuntu WSL process boundary and exactly-one task handoff. It does not claim full upstream Hermes agent execution yet; the next #232 slice should swap the example runtime command for the confirmed read-only Hermes/FURYOKU launch command.

Fixes part of #232.