### PR TITLE
[codex] Add Hermes launch adapter

### DIFF
--- a/docs/hermes-launch-bridge.md
+++ b/docs/hermes-launch-bridge.md
@@ -120,3 +120,62 @@ python -m furyoku.cli hermes-bridge `
 On the current handoff host, `<furyoku-repo-wsl-path>` resolved to `/mnt/c/Users/Allan/OneDrive/Documents/FURYOKU-local-model-roster-refresh`.
 
 To execute Hermes itself, replace the handoff command with the confirmed Hermes/FURYOKU launch command from the read-only WSL checkout. The scaffold must not be widened into multi-Symbiote execution until the one-Symbiote live handoff is proven.
+
+## Hermes Runtime Adapter
+
+`examples/hermes_bridge_hermes_runtime.py` is the first FURYOKU-owned adapter for the actual Hermes CLI. It reads the validated live bridge payload from stdin, invokes exactly one `hermes chat --query ... --quiet` process, and returns a structured JSON runtime payload with:
+
+- bridge execution key
+- Symbiote id, role, and task id
+- selected FURYOKU model/provider evidence
+- Hermes command argv without secret values
+- stdout/stderr, exit code, timeout state, elapsed timing, and recoverable error details
+
+The adapter does not store credentials and does not mutate `JKhyro/HERMES-AGENT`. It only runs the Hermes CLI already installed in WSL.
+
+Current host command shape:
+
+```powershell
+python -m furyoku.cli hermes-bridge `
+  --registry .\examples\model_registry.example.json `
+  --envelope .\examples\hermes_bridge_one_symbiote.example.json `
+  --timeout-seconds 180 `
+  --handoff-command wsl -d Ubuntu python3 /mnt/c/Users/Allan/OneDrive/Documents/FURYOKU-local-model-roster-refresh/examples/hermes_bridge_hermes_runtime.py `
+    --hermes-command /root/.venvs/hermes-agent-smoke/bin/hermes `
+    --max-turns 1
+```
+
+If Hermes needs an explicit provider/model override for the first smoke, pass it to the adapter, not to FURYOKU routing:
+
+```powershell
+    --provider openrouter `
+    --model anthropic/claude-sonnet-4.6
+```
+
+FURYOKU still records the selected model from its own routing evidence. The adapter override only tells Hermes which configured runtime provider to use for the one bounded execution.
+
+## Hermes Provider/Auth Gate
+
+On this host, the Hermes checkout and venv are usable, but the actual agent cannot execute a prompt yet because no provider credentials/config are present:
+
+```powershell
+wsl -d Ubuntu -- /root/.venvs/hermes-agent-smoke/bin/hermes status
+wsl -d Ubuntu -- /root/.venvs/hermes-agent-smoke/bin/hermes chat --query "Reply with one short sentence confirming the Hermes/FURYOKU bridge received this task." --quiet --source furyoku-bridge --max-turns 1
+```
+
+Observed blocker:
+
+- `/root/.hermes/.env` is not present.
+- Hermes model/provider is not set.
+- API-key providers and OAuth providers report not configured.
+- `hermes chat --query ...` exits before execution with first-run non-interactive setup guidance.
+
+Minimum non-interactive configuration is provider-specific. Hermes currently suggests either setting provider environment variables such as `OPENROUTER_API_KEY` or `OPENAI_API_KEY`, or configuring a custom endpoint with:
+
+```bash
+hermes config set model.provider custom
+hermes config set model.base_url http://localhost:8080/v1
+hermes config set model.default your-model-name
+```
+
+After that provider/auth gate is resolved, rerun the adapter command above. A successful one-Symbiote Hermes execution is required before the lane advances to any three-Symbiote smoke.

--- a/examples/hermes_bridge_hermes_runtime.py
+++ b/examples/hermes_bridge_hermes_runtime.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from typing import Any, Mapping
+
+
+HERMES_PROVIDERS = {
+    "auto",
+    "openrouter",
+    "nous",
+    "openai-codex",
+    "copilot-acp",
+    "copilot",
+    "anthropic",
+    "huggingface",
+    "zai",
+    "kimi-coding",
+    "minimax",
+    "minimax-cn",
+    "kilocode",
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run one FURYOKU bridge payload through the Hermes Agent CLI.",
+    )
+    parser.add_argument(
+        "--hermes-command",
+        default=os.getenv("FURYOKU_HERMES_COMMAND", "hermes"),
+        help="Hermes executable command. Defaults to FURYOKU_HERMES_COMMAND or hermes.",
+    )
+    parser.add_argument(
+        "--hermes-command-json",
+        default=os.getenv("FURYOKU_HERMES_COMMAND_JSON", ""),
+        help="JSON array form of the Hermes command, used when paths need exact tokenization.",
+    )
+    parser.add_argument(
+        "--provider",
+        default=os.getenv("FURYOKU_HERMES_PROVIDER", ""),
+        help="Optional Hermes provider override. Defaults to FURYOKU_HERMES_PROVIDER.",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.getenv("FURYOKU_HERMES_MODEL", ""),
+        help="Optional Hermes model override. Defaults to FURYOKU_HERMES_MODEL.",
+    )
+    parser.add_argument(
+        "--toolsets",
+        default=os.getenv("FURYOKU_HERMES_TOOLSETS", ""),
+        help="Optional Hermes toolset list. Defaults to FURYOKU_HERMES_TOOLSETS.",
+    )
+    parser.add_argument(
+        "--skills",
+        action="append",
+        default=None,
+        help="Optional Hermes skill preload. May be repeated.",
+    )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=_positive_int_env("FURYOKU_HERMES_MAX_TURNS", 1),
+        help="Maximum Hermes tool-calling turns for this one task.",
+    )
+    parser.add_argument(
+        "--source",
+        default=os.getenv("FURYOKU_HERMES_SOURCE", "furyoku-bridge"),
+        help="Hermes session source tag.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=_positive_float_env("FURYOKU_HERMES_TIMEOUT_SECONDS", 120.0),
+        help="Timeout for the Hermes subprocess.",
+    )
+    parser.add_argument(
+        "--cwd",
+        default=os.getenv("FURYOKU_HERMES_CWD", ""),
+        help="Optional working directory for Hermes.",
+    )
+    args = parser.parse_args(argv)
+
+    started = time.perf_counter()
+    try:
+        payload = json.load(sys.stdin)
+        envelope = _mapping(payload.get("envelope"), "payload.envelope")
+        task = _mapping(envelope.get("task"), "payload.envelope.task")
+        selected = _mapping(payload.get("selectedModel"), "payload.selectedModel", required=False)
+        command = _build_hermes_command(args, envelope, selected)
+    except Exception as exc:
+        _emit(
+            _result_payload(
+                started,
+                status="error",
+                error={
+                    "recoverable": True,
+                    "code": "invalid_bridge_payload",
+                    "message": str(exc),
+                },
+            )
+        )
+        return 2
+
+    try:
+        completed = subprocess.run(
+            command,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            timeout=args.timeout_seconds,
+            cwd=args.cwd or None,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        _emit(
+            _result_payload(
+                started,
+                payload=payload,
+                command=command,
+                status="timeout",
+                stdout=_coerce_text(exc.stdout),
+                stderr=_coerce_text(exc.stderr),
+                timed_out=True,
+                error={
+                    "recoverable": True,
+                    "code": "hermes_timeout",
+                    "message": f"Hermes command timed out after {exc.timeout} seconds",
+                },
+            )
+        )
+        return 124
+    except OSError as exc:
+        _emit(
+            _result_payload(
+                started,
+                payload=payload,
+                command=command,
+                status="error",
+                error={
+                    "recoverable": True,
+                    "code": "hermes_launch_failed",
+                    "message": str(exc),
+                },
+            )
+        )
+        return 127
+
+    ok = completed.returncode == 0
+    _emit(
+        _result_payload(
+            started,
+            payload=payload,
+            command=command,
+            status="ok" if ok else "error",
+            exit_code=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+            error=None
+            if ok
+            else {
+                "recoverable": True,
+                "code": "hermes_execution_failed",
+                "message": f"Hermes command exited with code {completed.returncode}",
+            },
+        )
+    )
+    return completed.returncode
+
+
+def _build_hermes_command(args: argparse.Namespace, envelope: Mapping[str, Any], selected: Mapping[str, Any]) -> list[str]:
+    prompt = _required_string(envelope, "prompt")
+    selected_model = _optional_string(selected, "modelId")
+    selected_provider = _optional_string(selected, "provider")
+    provider = (args.provider or "").strip()
+    model = (args.model or selected_model or "").strip()
+
+    command = _command_tokens(args)
+    command.extend(["chat", "--query", prompt, "--quiet", "--max-turns", str(args.max_turns), "--source", args.source])
+    if model:
+        command.extend(["--model", model])
+    if provider:
+        if provider not in HERMES_PROVIDERS:
+            raise ValueError(f"unsupported Hermes provider override {provider!r}")
+        command.extend(["--provider", provider])
+    elif selected_provider in HERMES_PROVIDERS:
+        command.extend(["--provider", selected_provider])
+    if args.toolsets:
+        command.extend(["--toolsets", args.toolsets])
+    for skill in args.skills or []:
+        command.extend(["--skills", skill])
+    return command
+
+
+def _command_tokens(args: argparse.Namespace) -> list[str]:
+    if args.hermes_command_json:
+        value = json.loads(args.hermes_command_json)
+        if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+            raise ValueError("--hermes-command-json must be a non-empty JSON string array")
+        return list(value)
+    return shlex.split(args.hermes_command, posix=(os.name != "nt"))
+
+
+def _result_payload(
+    started: float,
+    *,
+    payload: Mapping[str, Any] | None = None,
+    command: list[str] | None = None,
+    status: str,
+    exit_code: int | None = None,
+    stdout: str = "",
+    stderr: str = "",
+    timed_out: bool = False,
+    error: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    envelope = _mapping(payload.get("envelope"), "payload.envelope", required=False) if payload else {}
+    task = _mapping(envelope.get("task"), "payload.envelope.task", required=False) if envelope else {}
+    selected = _mapping(payload.get("selectedModel"), "payload.selectedModel", required=False) if payload else {}
+    return {
+        "schemaVersion": 1,
+        "adapter": "hermes-bridge-hermes-runtime",
+        "runtime": "hermes-agent",
+        "status": status,
+        "executionKey": _optional_string(envelope, "executionKey"),
+        "symbioteId": _optional_string(envelope, "symbioteId"),
+        "role": _optional_string(envelope, "role"),
+        "taskId": _optional_string(task, "taskId"),
+        "selectedModelId": _optional_string(selected, "modelId"),
+        "selectedProvider": _optional_string(selected, "provider"),
+        "hermesCommand": list(command or []),
+        "elapsedMs": round((time.perf_counter() - started) * 1000.0, 3),
+        "exitCode": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+        "timedOut": timed_out,
+        "responseText": stdout.strip() if status == "ok" else "",
+        "error": dict(error) if error is not None else None,
+    }
+
+
+def _mapping(value: Any, label: str, *, required: bool = True) -> Mapping[str, Any]:
+    if value is None and not required:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _required_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _coerce_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _emit(payload: Mapping[str, Any]) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hermes_runtime_adapter.py
+++ b/tests/test_hermes_runtime_adapter.py
@@ -1,0 +1,149 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ADAPTER = Path(__file__).resolve().parents[1] / "examples" / "hermes_bridge_hermes_runtime.py"
+
+
+def bridge_payload() -> dict:
+    return {
+        "schemaVersion": 1,
+        "bridge": "hermes-furyoku",
+        "mode": "live",
+        "envelope": {
+            "schemaVersion": 1,
+            "symbioteId": "symbiote-01",
+            "role": "primary",
+            "task": {
+                "taskId": "hermes.bridge.one-symbiote",
+                "requiredCapabilities": {
+                    "conversation": 0.8,
+                    "instruction_following": 0.8,
+                },
+                "privacyRequirement": "prefer_local",
+            },
+            "prompt": "Confirm the live Hermes bridge.",
+            "routing": {
+                "checkHealth": True,
+                "fallback": True,
+                "maxAttempts": 2,
+            },
+            "executionKey": "symbiote-01:primary:hermes.bridge.one-symbiote",
+        },
+        "selectedModel": {
+            "modelId": "local-echo",
+            "provider": "local",
+            "eligible": True,
+            "score": 1.0,
+            "reasons": [],
+            "blockers": [],
+        },
+        "decisionReport": {},
+        "readiness": [],
+    }
+
+
+class HermesRuntimeAdapterTests(unittest.TestCase):
+    def test_adapter_invokes_hermes_chat_with_bridge_prompt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            argv_path = temp_path / "argv.json"
+            fake_hermes = temp_path / "fake_hermes.py"
+            fake_hermes.write_text(
+                "import json, pathlib, sys\n"
+                "pathlib.Path(sys.argv[1]).write_text(json.dumps(sys.argv[2:]), encoding='utf-8')\n"
+                "print('Hermes bridge received task.')\n",
+                encoding="utf-8",
+            )
+            command_json = json.dumps([sys.executable, str(fake_hermes), str(argv_path)])
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ADAPTER),
+                    "--hermes-command-json",
+                    command_json,
+                    "--provider",
+                    "auto",
+                    "--max-turns",
+                    "1",
+                ],
+                input=json.dumps(bridge_payload()),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            payload = json.loads(completed.stdout)
+            argv = json.loads(argv_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["adapter"], "hermes-bridge-hermes-runtime")
+        self.assertEqual(payload["runtime"], "hermes-agent")
+        self.assertEqual(payload["executionKey"], "symbiote-01:primary:hermes.bridge.one-symbiote")
+        self.assertEqual(payload["selectedModelId"], "local-echo")
+        self.assertIn("Hermes bridge received task.", payload["responseText"])
+        self.assertIn("chat", argv)
+        self.assertIn("--query", argv)
+        self.assertIn("Confirm the live Hermes bridge.", argv)
+        self.assertIn("--provider", argv)
+        self.assertIn("auto", argv)
+        self.assertIn("--model", argv)
+        self.assertIn("local-echo", argv)
+
+    def test_adapter_returns_structured_error_when_hermes_fails(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_hermes = temp_path / "fake_hermes_fail.py"
+            fake_hermes.write_text(
+                "import sys\n"
+                "sys.stderr.write('no provider configured')\n"
+                "sys.exit(7)\n",
+                encoding="utf-8",
+            )
+            command_json = json.dumps([sys.executable, str(fake_hermes)])
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ADAPTER),
+                    "--hermes-command-json",
+                    command_json,
+                    "--max-turns",
+                    "1",
+                ],
+                input=json.dumps(bridge_payload()),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 7)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["exitCode"], 7)
+        self.assertEqual(payload["stderr"], "no provider configured")
+        self.assertEqual(payload["error"]["code"], "hermes_execution_failed")
+
+    def test_adapter_rejects_malformed_bridge_payload(self):
+        completed = subprocess.run(
+            [sys.executable, str(ADAPTER), "--hermes-command-json", json.dumps([sys.executable])],
+            input=json.dumps({"envelope": {}}),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["error"]["code"], "invalid_bridge_payload")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the next #232 one-Symbiote Hermes launch slice after the live process-boundary bridge.

- Adds `examples/hermes_bridge_hermes_runtime.py`, a FURYOKU-owned adapter that reads the validated bridge payload from stdin and invokes exactly one `hermes chat --query ... --quiet` process.
- Emits structured runtime JSON with execution key, Symbiote/task identity, selected FURYOKU model evidence, Hermes argv, stdout/stderr, exit code, elapsed timing, timeout state, and recoverable errors.
- Documents the current WSL command shape and the remaining Hermes provider/auth gate without mutating `JKhyro/HERMES-AGENT` or storing secrets.
- Adds focused tests for success, Hermes failure, and malformed payload handling.

## Validation

- `python -m unittest tests.test_hermes_runtime_adapter tests.test_hermes_bridge -q`
- `python -m unittest tests.test_hermes_runtime_adapter tests.test_hermes_bridge tests.test_cli -q`
- `python -m py_compile examples/hermes_bridge_hermes_runtime.py`
- `git diff --cached --check`
- Live WSL bridge probe with the adapter against `/root/.venvs/hermes-agent-smoke/bin/hermes`; result is the expected structured recoverable blocker because Hermes has no provider/auth config yet.

Refs #232. Parent lane: #230.