### PR TITLE
[codex] Detect Hermes reported failures

### DIFF
--- a/docs/hermes-launch-bridge.md
+++ b/docs/hermes-launch-bridge.md
@@ -133,6 +133,8 @@ To execute Hermes itself, replace the handoff command with the confirmed Hermes/
 
 The adapter does not store credentials and does not mutate `JKhyro/HERMES-AGENT`. It only runs the Hermes CLI already installed in WSL.
 
+If Hermes exits successfully while printing a terminal agent failure such as exhausted API retries or a final provider error, the adapter treats that as a recoverable runtime failure instead of a successful Symbiote execution. That keeps the bridge from advancing on a session id or setup/error transcript alone.
+
 Current host command shape:
 
 ```powershell

--- a/examples/hermes_bridge_hermes_runtime.py
+++ b/examples/hermes_bridge_hermes_runtime.py
@@ -153,7 +153,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 127
 
-    ok = completed.returncode == 0
+    reported_error = _detect_hermes_reported_failure(completed.stdout or "")
+    ok = completed.returncode == 0 and reported_error is None
     _emit(
         _result_payload(
             started,
@@ -165,14 +166,15 @@ def main(argv: list[str] | None = None) -> int:
             stderr=completed.stderr or "",
             error=None
             if ok
-            else {
+            else reported_error
+            or {
                 "recoverable": True,
                 "code": "hermes_execution_failed",
                 "message": f"Hermes command exited with code {completed.returncode}",
             },
         )
     )
-    return completed.returncode
+    return completed.returncode if reported_error is None else 1
 
 
 def _build_hermes_command(args: argparse.Namespace, envelope: Mapping[str, Any], selected: Mapping[str, Any]) -> list[str]:
@@ -271,6 +273,23 @@ def _coerce_text(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value
+
+
+def _detect_hermes_reported_failure(stdout: str) -> Mapping[str, Any] | None:
+    lowered = stdout.lower()
+    failure_markers = (
+        "api call failed after",
+        "final error:",
+        "rate limit persisted",
+        "max retries",
+    )
+    if not any(marker in lowered for marker in failure_markers):
+        return None
+    return {
+        "recoverable": True,
+        "code": "hermes_reported_failure",
+        "message": "Hermes reported a failed agent execution despite exiting successfully",
+    }
 
 
 def _positive_int_env(name: str, default: int) -> int:

--- a/tests/test_hermes_runtime_adapter.py
+++ b/tests/test_hermes_runtime_adapter.py
@@ -130,6 +130,39 @@ class HermesRuntimeAdapterTests(unittest.TestCase):
         self.assertEqual(payload["stderr"], "no provider configured")
         self.assertEqual(payload["error"]["code"], "hermes_execution_failed")
 
+    def test_adapter_reports_hermes_stdout_failure_even_with_zero_exit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_hermes = temp_path / "fake_hermes_soft_fail.py"
+            fake_hermes.write_text(
+                "print('API call failed after 3 retries: quota exceeded')\n"
+                "print('Final error: quota exceeded')\n",
+                encoding="utf-8",
+            )
+            command_json = json.dumps([sys.executable, str(fake_hermes)])
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ADAPTER),
+                    "--hermes-command-json",
+                    command_json,
+                    "--max-turns",
+                    "1",
+                ],
+                input=json.dumps(bridge_payload()),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 1)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["exitCode"], 0)
+        self.assertIn("quota exceeded", payload["stdout"])
+        self.assertEqual(payload["error"]["code"], "hermes_reported_failure")
+
     def test_adapter_rejects_malformed_bridge_payload(self):
         completed = subprocess.run(
             [sys.executable, str(ADAPTER), "--hermes-command-json", json.dumps([sys.executable])],


### PR DESCRIPTION
## Summary

Fixes a #232 adapter finding from the bounded provider/auth smoke.

- Detects terminal Hermes agent failures printed to stdout even when the Hermes CLI exits with code `0`.
- Converts those transcripts into a recoverable `hermes_reported_failure` adapter error and non-zero adapter exit.
- Adds regression coverage for a zero-exit Hermes stdout failure.
- Documents that a session id or error transcript alone must not count as a successful Symbiote execution.

## Validation

- `python -m unittest tests.test_hermes_runtime_adapter tests.test_hermes_bridge -q`
- `python -m unittest tests.test_hermes_runtime_adapter tests.test_hermes_bridge tests.test_cli -q`
- `python -m py_compile examples/hermes_bridge_hermes_runtime.py`
- `git diff --cached --check`
- Live FURYOKU adapter probe with transient WSL `OPENAI_API_KEY` pass-through and Hermes custom OpenAI config now returns `ok=false` with runtime error `hermes_reported_failure` instead of false success when the provider reports quota exhaustion.

Refs #232. Parent lane: #230.