### PR TITLE
[codex] Add character-array-run ACA execution surface (#282)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Completed runtime adoption lane: [#230](https://github.com/JKhyro/FURYOKU/issues/230) established Hermes Agent as the FURYOKU runtime base
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Completed closeout lane: [#278](https://github.com/JKhyro/FURYOKU/issues/278) aligned local/GitHub truth for the [#230](https://github.com/JKhyro/FURYOKU/issues/230) parent closeout after [#276](https://github.com/JKhyro/FURYOKU/issues/276) reconciled bridge/migration docs
-- Current active lane: [#280](https://github.com/JKhyro/FURYOKU/issues/280) formalizes the Adaptive Response Array (ARA) and Agentic Character Array (ACA) composition surfaces on top of the completed [#97](https://github.com/JKhyro/FURYOKU/issues/97) CHARACTER envelope groundwork
+- Current active lane: [#282](https://github.com/JKhyro/FURYOKU/issues/282) adds the `character-array-run` ACA execution surface (`execute_character_array_member` + CLI) on top of the landed [#280](https://github.com/JKhyro/FURYOKU/issues/280) ARA/ACA composition contract
 - Future runtime work: open a new explicitly scoped issue; do not infer runtime launch, scheduler expansion, OpenClaw work, or Ubuntu/WSL/Ubuntu-VM work from the completed [#230](https://github.com/JKhyro/FURYOKU/issues/230) lane
 
 ## Current Baseline
@@ -213,6 +213,8 @@ python -m furyoku.cli character-select --registry .\examples\model_registry.exam
 python -m furyoku.cli character-select --registry .\examples\model_registry.example.json --character-profile .\examples\character_profile.kira-array.json --output .\character-envelope.json
 python -m furyoku.cli character-run --registry .\examples\model_registry.example.json --character-profile .\examples\character_profile.tertiary-symbiote.json --prompt "Hello"
 python -m furyoku.cli character-array-select --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --output .\aca-envelope.json
+python -m furyoku.cli character-array-run --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --prompt "Hello"
+python -m furyoku.cli character-array-run --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --slot-id tertiary-support --role-id primary --prompt "Summarise"
 ```
 
 ## Character Composition Doctrine (ARA / ACA)
@@ -220,7 +222,8 @@ python -m furyoku.cli character-array-select --registry .\examples\model_registr
 FURYOKU names the two CHARACTER composition surfaces explicitly, in line with the CORTEX character doctrine:
 
 - **Adaptive Response Array (ARA)** — one CHARACTER. An ARA is a bound set of role components (one optional primary plus any number of secondaries, each with its own task requirements and up to twelve subagents). This is the surface produced by [`furyoku/character_profiles.py`](furyoku/character_profiles.py) and consumed by `character-select` / `character-run`.
-- **Agentic Character Array (ACA)** — an array of CHARACTERS. An ACA composes one or more ARA profiles (each one full CHARACTER) into a single executable orchestration envelope, preserving per-character primary/secondary responsibility as well as array-level totals (character count, total role count, total subagent capacity). This is the surface produced by [`furyoku/character_arrays.py`](furyoku/character_arrays.py) and consumed by `character-array-select`.
+- **Agentic Character Array (ACA)** — an array of CHARACTERS. An ACA composes one or more ARA profiles (each one full CHARACTER) into a single executable orchestration envelope, preserving per-character primary/secondary responsibility as well as array-level totals (character count, total role count, total subagent capacity). This is the surface produced by [`furyoku/character_arrays.py`](furyoku/character_arrays.py) and consumed by `character-array-select` / `character-array-run`.
+- **ACA execution** — `character-array-run` (and the `execute_character_array_member` runtime helper) resolves one ACA member at a time: by default the primary member plus that member's primary role, or a named `--slot-id` / `--role-id` pair. The JSON report carries the selected slot, character id, executed role, chosen model, execution outcome, and the full per-role assignment envelope for that CHARACTER.
 
 An ACA member can reference an existing CHARACTER profile on disk through `profilePath`, embed one inline through `character`, or attach one through `profile`. Exactly one of those three fields must be present per member. Aliases and responsibilities are optional metadata that travel into the envelope for downstream orchestration.
 

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -152,6 +152,7 @@ from .outcome_feedback import (
     summarize_outcome_feedback,
 )
 from .runtime import (
+    CharacterArrayMemberExecutionResult,
     CharacterRoleExecutionResult,
     ComparativeExecutionBatchResult,
     ComparativeEvaluationResult,
@@ -163,6 +164,7 @@ from .runtime import (
     compare_model_executions,
     execute_decision_situation,
     execute_decision_situation_with_fallback,
+    execute_character_array_member,
     execute_character_role,
     route_and_execute,
     route_and_execute_with_fallback,
@@ -206,6 +208,7 @@ __all__ = [
     "CharacterArrayError",
     "CharacterArrayMember",
     "CharacterArrayMemberEnvelope",
+    "CharacterArrayMemberExecutionResult",
     "CharacterArrayMemberSelection",
     "CharacterArraySelection",
     "CharacterCompositionSelection",
@@ -305,6 +308,7 @@ __all__ = [
     "execute_model",
     "compare_decision_situation_executions",
     "compare_model_executions",
+    "execute_character_array_member",
     "execute_character_role",
     "execute_decision_situation",
     "execute_decision_situation_with_fallback",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -54,6 +54,7 @@ from .hermes_bridge import (
     load_hermes_three_symbiote_smoke,
 )
 from .runtime import (
+    CharacterArrayMemberExecutionResult,
     CharacterRoleExecutionResult,
     ComparativeExecutionBatchResult,
     ComparativeEvaluationResult,
@@ -62,6 +63,7 @@ from .runtime import (
     compare_decision_suite_executions,
     compare_decision_situation_executions,
     compare_model_executions,
+    execute_character_array_member,
     execute_character_role,
     execute_decision_situation,
     execute_decision_situation_with_fallback,
@@ -499,6 +501,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         _write_json(envelope.to_dict(), output_path=args.output)
         return 0
+
+    if args.command == "character-array-run":
+        array = load_character_array(args.character_array)
+        readiness = _readiness_from_args(args, models)
+        result = execute_character_array_member(
+            models,
+            array,
+            ProviderExecutionRequest(args.prompt, timeout_seconds=args.timeout_seconds),
+            slot_id=args.slot_id,
+            role_id=args.role_id,
+            allow_reuse=not args.no_reuse,
+            readiness=readiness,
+        )
+        _write_json(_character_array_member_result_to_dict(result), output_path=args.output)
+        return 0 if result.ok else 2
 
     parser.error(f"unsupported command {args.command}")
     return 2
@@ -1026,6 +1043,55 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_health_decision_args(
         character_array_parser,
         "Run provider readiness checks before assigning CHARACTER ARRAY members.",
+    )
+    character_array_run_parser = subparsers.add_parser(
+        "character-array-run",
+        help="Select CHARACTER ARRAY (ACA) member assignments and execute one member's role.",
+    )
+    character_array_run_parser.add_argument(
+        "--registry",
+        required=True,
+        type=Path,
+        help="Path to a FURYOKU model registry JSON file.",
+    )
+    character_array_run_parser.add_argument(
+        "--character-array",
+        required=True,
+        type=Path,
+        help="Path to a FURYOKU Agentic Character Array (ACA) JSON file.",
+    )
+    character_array_run_parser.add_argument(
+        "--prompt",
+        required=True,
+        help="Prompt text passed to the selected CHARACTER ARRAY member role.",
+    )
+    character_array_run_parser.add_argument(
+        "--slot-id",
+        help="CHARACTER ARRAY slot (alias) to execute. Defaults to the array's primary member.",
+    )
+    character_array_run_parser.add_argument(
+        "--role-id",
+        help="CHARACTER role id inside the selected member to execute. Defaults to that member's primary role.",
+    )
+    character_array_run_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=60.0,
+        help="Execution timeout in seconds.",
+    )
+    character_array_run_parser.add_argument(
+        "--no-reuse",
+        action="store_true",
+        help="Require each CHARACTER role across every member to use a distinct registered model.",
+    )
+    character_array_run_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to persist the JSON CHARACTER ARRAY member execution report.",
+    )
+    _add_health_decision_args(
+        character_array_run_parser,
+        "Run provider readiness checks before assigning and executing a CHARACTER ARRAY member role.",
     )
     return parser
 
@@ -1740,6 +1806,24 @@ def _decision_report_to_dict(report: ModelDecisionReport, *, readiness=None) -> 
 def _character_role_result_to_dict(result: CharacterRoleExecutionResult) -> dict:
     return {
         "ok": result.ok,
+        "characterId": result.character_id,
+        "executedRoleId": result.role_id,
+        "selectedModel": _score_to_dict(result.selection),
+        "execution": _execution_to_dict(result.execution),
+        "roleAssignments": _character_profile_selection_to_dict(result.character_selection),
+    }
+
+
+def _character_array_member_result_to_dict(
+    result: CharacterArrayMemberExecutionResult,
+) -> dict:
+    return {
+        "ok": result.ok,
+        "arrayId": result.array_id,
+        "slotId": result.slot_id,
+        "alias": result.member.alias,
+        "responsibility": result.member.responsibility,
+        "primary": result.primary,
         "characterId": result.character_id,
         "executedRoleId": result.role_id,
         "selectedModel": _score_to_dict(result.selection),

--- a/furyoku/runtime.py
+++ b/furyoku/runtime.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Mapping
 
+from .character_arrays import (
+    CharacterArray,
+    CharacterArrayError,
+    CharacterArrayMember,
+)
 from .character_profiles import CharacterProfile, CharacterProfileSelection, select_character_profile_models
 from .model_decisions import (
     DecisionSuite,
@@ -82,6 +87,56 @@ class CharacterRoleExecutionResult:
     @property
     def provider(self) -> str:
         return self.selection.model.provider
+
+
+@dataclass(frozen=True)
+class CharacterArrayMemberExecutionResult:
+    """One CHARACTER ARRAY (ACA) member's selected role executed through a provider adapter."""
+
+    array: CharacterArray
+    member: CharacterArrayMember
+    slot_id: str
+    role_result: CharacterRoleExecutionResult
+
+    @property
+    def ok(self) -> bool:
+        return self.role_result.ok
+
+    @property
+    def array_id(self) -> str:
+        return self.array.array_id
+
+    @property
+    def character_id(self) -> str:
+        return self.role_result.character_id
+
+    @property
+    def role_id(self) -> str:
+        return self.role_result.role_id
+
+    @property
+    def primary(self) -> bool:
+        return self.member.primary
+
+    @property
+    def selection(self) -> ModelScore:
+        return self.role_result.selection
+
+    @property
+    def execution(self) -> ProviderExecutionResult:
+        return self.role_result.execution
+
+    @property
+    def character_selection(self) -> CharacterProfileSelection:
+        return self.role_result.character_selection
+
+    @property
+    def model_id(self) -> str:
+        return self.role_result.model_id
+
+    @property
+    def provider(self) -> str:
+        return self.role_result.provider
 
 
 @dataclass(frozen=True)
@@ -545,6 +600,47 @@ def execute_character_role(
         role_id=resolved_role_id,
         selection=selection,
         execution=execution,
+    )
+
+
+def execute_character_array_member(
+    models: list[ModelEndpoint],
+    array: CharacterArray,
+    request: ProviderExecutionRequest | str,
+    *,
+    slot_id: str | None = None,
+    role_id: str | None = None,
+    allow_reuse: bool = True,
+    readiness: ReadinessEvidenceInput | None = None,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> CharacterArrayMemberExecutionResult:
+    """Execute one role on one CHARACTER member of an Agentic Character Array."""
+
+    if not isinstance(array, CharacterArray):
+        raise CharacterArrayError(
+            "CHARACTER ARRAY execution requires a parsed CharacterArray"
+        )
+    if slot_id is None:
+        member = next(
+            (candidate for candidate in array.members if candidate.primary),
+            array.members[0],
+        )
+    else:
+        member = array.member(slot_id)
+    role_result = execute_character_role(
+        models,
+        member.profile,
+        request,
+        role_id=role_id,
+        allow_reuse=allow_reuse,
+        readiness=readiness,
+        adapters=adapters,
+    )
+    return CharacterArrayMemberExecutionResult(
+        array=array,
+        member=member,
+        slot_id=member.slot_id,
+        role_result=role_result,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2578,6 +2578,151 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["members"][1]["character"]["characterId"], "cli-support")
             self.assertIn("generatedAt", persisted["reportMetadata"])
 
+    def test_character_array_run_executes_primary_member_default_role(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            character_path = Path(temp_dir) / "character.json"
+            array_path = Path(temp_dir) / "array.json"
+            output_path = Path(temp_dir) / "reports" / "character-array-run.json"
+            write_executable_character_registry(registry_path)
+            write_character_profile(character_path)
+            array_payload = {
+                "schemaVersion": 1,
+                "arrayId": "cli-aca-run",
+                "class": "Symbiote",
+                "rank": "Prototype",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "profilePath": str(character_path),
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "cli-support",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "maxSubagents": 0,
+                                    "task": {
+                                        "taskId": "cli-support.primary",
+                                        "requiredCapabilities": {"conversation": 0.7},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+            array_path.write_text(json.dumps(array_payload), encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "character-array-run",
+                        "--registry",
+                        str(registry_path),
+                        "--character-array",
+                        str(array_path),
+                        "--prompt",
+                        "hello",
+                        "--output",
+                        str(output_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            persisted = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["arrayId"], "cli-aca-run")
+            self.assertEqual(payload["slotId"], "lead")
+            self.assertTrue(payload["primary"])
+            self.assertEqual(payload["characterId"], "test-character")
+            self.assertEqual(payload["executedRoleId"], "primary")
+            self.assertEqual(payload["selectedModel"]["modelId"], "local-echo")
+            self.assertEqual(payload["execution"]["responseText"].strip(), "echo:hello")
+            self.assertEqual(payload["roleAssignments"]["primaryRole"], "primary")
+            self.assertIn("generatedAt", persisted["reportMetadata"])
+            self.assertEqual(persisted["slotId"], "lead")
+
+    def test_character_array_run_executes_named_slot_and_role(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            character_path = Path(temp_dir) / "character.json"
+            array_path = Path(temp_dir) / "array.json"
+            write_executable_character_registry(registry_path)
+            write_character_profile(character_path)
+            array_payload = {
+                "schemaVersion": 1,
+                "arrayId": "cli-aca-named",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "profilePath": str(character_path),
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "cli-support-named",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "cli-support-named.primary",
+                                        "requiredCapabilities": {"conversation": 0.7},
+                                    },
+                                },
+                                {
+                                    "roleId": "coding",
+                                    "maxSubagents": 2,
+                                    "task": {
+                                        "taskId": "cli-support-named.coding",
+                                        "requireTools": True,
+                                        "requiredCapabilities": {"coding": 0.9},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+            array_path.write_text(json.dumps(array_payload), encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "character-array-run",
+                        "--registry",
+                        str(registry_path),
+                        "--character-array",
+                        str(array_path),
+                        "--slot-id",
+                        "support",
+                        "--role-id",
+                        "coding",
+                        "--prompt",
+                        "write code",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["slotId"], "support")
+            self.assertFalse(payload["primary"])
+            self.assertEqual(payload["executedRoleId"], "coding")
+            self.assertEqual(payload["selectedModel"]["modelId"], "cli-coder")
+            self.assertEqual(payload["execution"]["responseText"].strip(), "code:write code")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,6 +2,7 @@ import subprocess
 import unittest
 
 from furyoku import (
+    CharacterArrayError,
     DecisionOutcomeRecord,
     ModelDecisionError,
     ModelEndpoint,
@@ -14,9 +15,11 @@ from furyoku import (
     compare_decision_suite_executions,
     compare_decision_situation_executions,
     compare_model_executions,
+    execute_character_array_member,
     execute_decision_situation,
     execute_decision_situation_with_fallback,
     execute_character_role,
+    parse_character_array,
     parse_decision_suite,
     parse_character_profile,
     route_and_execute,
@@ -736,6 +739,196 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(result.provider, "cli")
         self.assertEqual(result.character_selection.max_subagents_for("coding"), 4)
         self.assertEqual(result.execution.response_text, "cli-coder:write code")
+
+    def test_execute_character_array_member_defaults_to_primary_slot_and_role(self):
+        array = parse_character_array(
+            {
+                "schemaVersion": 1,
+                "arrayId": "runtime-aca",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "lead-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "lead-character.primary",
+                                        "privacyRequirement": "local_only",
+                                        "requiredCapabilities": {"conversation": 0.9},
+                                    },
+                                },
+                                {
+                                    "roleId": "coding",
+                                    "task": {
+                                        "taskId": "lead-character.coding",
+                                        "requireTools": True,
+                                        "requiredCapabilities": {"coding": 0.9},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "support-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "support-character.primary",
+                                        "requireTools": True,
+                                        "requiredCapabilities": {"coding": 0.9},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+        )
+
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = execute_character_array_member(
+            [local_endpoint(), cli_endpoint()],
+            array,
+            "hello",
+            adapters={
+                "local": SubprocessProviderAdapter(runner),
+                "cli": SubprocessProviderAdapter(runner),
+            },
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.array_id, "runtime-aca")
+        self.assertEqual(result.slot_id, "lead")
+        self.assertTrue(result.primary)
+        self.assertEqual(result.character_id, "lead-character")
+        self.assertEqual(result.role_id, "primary")
+        self.assertEqual(result.model_id, "local-chat")
+        self.assertEqual(result.execution.response_text, "local-chat:hello")
+
+    def test_execute_character_array_member_selects_named_slot_and_role(self):
+        array = parse_character_array(
+            {
+                "schemaVersion": 1,
+                "arrayId": "runtime-aca-named",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "lead-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "lead-character.primary",
+                                        "privacyRequirement": "local_only",
+                                        "requiredCapabilities": {"conversation": 0.9},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "support-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "support-character.primary",
+                                        "requiredCapabilities": {"conversation": 0.5},
+                                    },
+                                },
+                                {
+                                    "roleId": "coding",
+                                    "maxSubagents": 3,
+                                    "task": {
+                                        "taskId": "support-character.coding",
+                                        "requireTools": True,
+                                        "requiredCapabilities": {"coding": 0.9},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        )
+
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = execute_character_array_member(
+            [local_endpoint(), cli_endpoint()],
+            array,
+            ProviderExecutionRequest("write code", timeout_seconds=2),
+            slot_id="support",
+            role_id="coding",
+            adapters={
+                "local": SubprocessProviderAdapter(runner),
+                "cli": SubprocessProviderAdapter(runner),
+            },
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.slot_id, "support")
+        self.assertFalse(result.primary)
+        self.assertEqual(result.character_id, "support-character")
+        self.assertEqual(result.role_id, "coding")
+        self.assertEqual(result.model_id, "cli-coder")
+        self.assertEqual(result.provider, "cli")
+        self.assertEqual(result.execution.response_text, "cli-coder:write code")
+        self.assertEqual(result.character_selection.max_subagents_for("coding"), 3)
+
+    def test_execute_character_array_member_rejects_unknown_slot(self):
+        array = parse_character_array(
+            {
+                "schemaVersion": 1,
+                "arrayId": "runtime-aca-unknown-slot",
+                "members": [
+                    {
+                        "alias": "solo",
+                        "primary": True,
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "solo-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "solo-character.primary",
+                                        "requiredCapabilities": {"conversation": 0.5},
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaises(CharacterArrayError) as error:
+            execute_character_array_member([local_endpoint()], array, "hello", slot_id="missing")
+
+        self.assertIn("Unknown CHARACTER ARRAY slot", str(error.exception))
 
     def test_execute_character_role_rejects_unknown_role(self):
         profile = parse_character_profile(


### PR DESCRIPTION
## Summary
- Adds `execute_character_array_member` runtime helper and `CharacterArrayMemberExecutionResult` dataclass, wrapping the existing `execute_character_role` ARA pipeline so one ACA member can be executed at a time.
- Adds `character-array-run` CLI command: defaults to the ACA's primary member + that member's primary role, or accepts `--slot-id` / `--role-id` to pick any member/role combination. JSON output carries array id, slot, character id, executed role, chosen model, execution outcome, and the full per-role assignment envelope for that CHARACTER.
- Exports new symbols through `furyoku/__init__.py`, documents the new surface in `README.md`, and bumps the active-lane banner from #280 to #282.

## Test plan
- [x] `python -m unittest tests.test_runtime tests.test_character_arrays tests.test_cli` (92 tests, all pass)
- [x] `python -m unittest discover -s tests` (315 tests, all pass, 591.9s)

Closes #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)