### PR TITLE
[codex] Add character-array-run-all full ACA fan-out surface (#284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ FURYOKU is the active AI lab program for custom LLM research, implementation, op
 - Completed runtime adoption lane: [#230](https://github.com/JKhyro/FURYOKU/issues/230) established Hermes Agent as the FURYOKU runtime base
 - Downstream CHARACTER/MOA groundwork completed: [#97](https://github.com/JKhyro/FURYOKU/issues/97)
 - Completed closeout lane: [#278](https://github.com/JKhyro/FURYOKU/issues/278) aligned local/GitHub truth for the [#230](https://github.com/JKhyro/FURYOKU/issues/230) parent closeout after [#276](https://github.com/JKhyro/FURYOKU/issues/276) reconciled bridge/migration docs
-- Current active lane: [#282](https://github.com/JKhyro/FURYOKU/issues/282) adds the `character-array-run` ACA execution surface (`execute_character_array_member` + CLI) on top of the landed [#280](https://github.com/JKhyro/FURYOKU/issues/280) ARA/ACA composition contract
+- Current active lane: [#284](https://github.com/JKhyro/FURYOKU/issues/284) adds the `character-array-run-all` full-array fan-out surface (`execute_character_array` + CLI) on top of the landed [#282](https://github.com/JKhyro/FURYOKU/issues/282) per-member ACA execution and [#280](https://github.com/JKhyro/FURYOKU/issues/280) ARA/ACA composition contract
 - Future runtime work: open a new explicitly scoped issue; do not infer runtime launch, scheduler expansion, OpenClaw work, or Ubuntu/WSL/Ubuntu-VM work from the completed [#230](https://github.com/JKhyro/FURYOKU/issues/230) lane
 
 ## Current Baseline
@@ -215,6 +215,8 @@ python -m furyoku.cli character-run --registry .\examples\model_registry.example
 python -m furyoku.cli character-array-select --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --output .\aca-envelope.json
 python -m furyoku.cli character-array-run --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --prompt "Hello"
 python -m furyoku.cli character-array-run --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --slot-id tertiary-support --role-id primary --prompt "Summarise"
+python -m furyoku.cli character-array-run-all --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --prompt "Hello" --output .\aca-fanout.json
+python -m furyoku.cli character-array-run-all --registry .\examples\model_registry.example.json --character-array .\examples\character_array.dual-symbiote.json --prompt "Hello" --role-id-for kira-lead=memory --role-id-for tertiary-support=primary
 ```
 
 ## Character Composition Doctrine (ARA / ACA)
@@ -224,6 +226,7 @@ FURYOKU names the two CHARACTER composition surfaces explicitly, in line with th
 - **Adaptive Response Array (ARA)** — one CHARACTER. An ARA is a bound set of role components (one optional primary plus any number of secondaries, each with its own task requirements and up to twelve subagents). This is the surface produced by [`furyoku/character_profiles.py`](furyoku/character_profiles.py) and consumed by `character-select` / `character-run`.
 - **Agentic Character Array (ACA)** — an array of CHARACTERS. An ACA composes one or more ARA profiles (each one full CHARACTER) into a single executable orchestration envelope, preserving per-character primary/secondary responsibility as well as array-level totals (character count, total role count, total subagent capacity). This is the surface produced by [`furyoku/character_arrays.py`](furyoku/character_arrays.py) and consumed by `character-array-select` / `character-array-run`.
 - **ACA execution** — `character-array-run` (and the `execute_character_array_member` runtime helper) resolves one ACA member at a time: by default the primary member plus that member's primary role, or a named `--slot-id` / `--role-id` pair. The JSON report carries the selected slot, character id, executed role, chosen model, execution outcome, and the full per-role assignment envelope for that CHARACTER.
+- **ACA fan-out** — `character-array-run-all` (and the `execute_character_array` runtime helper) executes every CHARACTER member of the array in one invocation, defaulting to each member's primary role, with optional `--role-id` (applied to every member) and `--role-id-for slot=role` (repeatable per-slot override). The consolidated JSON report carries array-level `ok`, successful/failed counts, and the per-member execution reports.
 
 An ACA member can reference an existing CHARACTER profile on disk through `profilePath`, embed one inline through `character`, or attach one through `profile`. Exactly one of those three fields must be present per member. Aliases and responsibilities are optional metadata that travel into the envelope for downstream orchestration.
 

--- a/furyoku/__init__.py
+++ b/furyoku/__init__.py
@@ -152,6 +152,7 @@ from .outcome_feedback import (
     summarize_outcome_feedback,
 )
 from .runtime import (
+    CharacterArrayExecutionResult,
     CharacterArrayMemberExecutionResult,
     CharacterRoleExecutionResult,
     ComparativeExecutionBatchResult,
@@ -164,6 +165,7 @@ from .runtime import (
     compare_model_executions,
     execute_decision_situation,
     execute_decision_situation_with_fallback,
+    execute_character_array,
     execute_character_array_member,
     execute_character_role,
     route_and_execute,
@@ -206,6 +208,7 @@ __all__ = [
     "CharacterArray",
     "CharacterArrayEnvelope",
     "CharacterArrayError",
+    "CharacterArrayExecutionResult",
     "CharacterArrayMember",
     "CharacterArrayMemberEnvelope",
     "CharacterArrayMemberExecutionResult",
@@ -308,6 +311,7 @@ __all__ = [
     "execute_model",
     "compare_decision_situation_executions",
     "compare_model_executions",
+    "execute_character_array",
     "execute_character_array_member",
     "execute_character_role",
     "execute_decision_situation",

--- a/furyoku/cli.py
+++ b/furyoku/cli.py
@@ -54,6 +54,7 @@ from .hermes_bridge import (
     load_hermes_three_symbiote_smoke,
 )
 from .runtime import (
+    CharacterArrayExecutionResult,
     CharacterArrayMemberExecutionResult,
     CharacterRoleExecutionResult,
     ComparativeExecutionBatchResult,
@@ -63,6 +64,7 @@ from .runtime import (
     compare_decision_suite_executions,
     compare_decision_situation_executions,
     compare_model_executions,
+    execute_character_array,
     execute_character_array_member,
     execute_character_role,
     execute_decision_situation,
@@ -515,6 +517,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             readiness=readiness,
         )
         _write_json(_character_array_member_result_to_dict(result), output_path=args.output)
+        return 0 if result.ok else 2
+
+    if args.command == "character-array-run-all":
+        array = load_character_array(args.character_array)
+        readiness = _readiness_from_args(args, models)
+        role_id_by_slot = _parse_slot_role_overrides(args.role_id_for or [])
+        result = execute_character_array(
+            models,
+            array,
+            ProviderExecutionRequest(args.prompt, timeout_seconds=args.timeout_seconds),
+            role_id_by_slot=role_id_by_slot,
+            default_role_id=args.role_id,
+            allow_reuse=not args.no_reuse,
+            readiness=readiness,
+        )
+        _write_json(_character_array_execution_result_to_dict(result), output_path=args.output)
         return 0 if result.ok else 2
 
     parser.error(f"unsupported command {args.command}")
@@ -1092,6 +1110,57 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_health_decision_args(
         character_array_run_parser,
         "Run provider readiness checks before assigning and executing a CHARACTER ARRAY member role.",
+    )
+    character_array_run_all_parser = subparsers.add_parser(
+        "character-array-run-all",
+        help="Execute every CHARACTER member of an Agentic Character Array (ACA) in one invocation.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--registry",
+        required=True,
+        type=Path,
+        help="Path to a FURYOKU model registry JSON file.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--character-array",
+        required=True,
+        type=Path,
+        help="Path to a FURYOKU Agentic Character Array (ACA) JSON file.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--prompt",
+        required=True,
+        help="Prompt text passed to every CHARACTER ARRAY member's selected role.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--role-id",
+        help="Default CHARACTER role id applied to every member. Defaults to each member's primary role.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--role-id-for",
+        action="append",
+        metavar="SLOT=ROLE",
+        help="Per-slot CHARACTER role override; repeat to set overrides for multiple slots.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=60.0,
+        help="Execution timeout in seconds applied to every member invocation.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--no-reuse",
+        action="store_true",
+        help="Require each CHARACTER role across every member to use a distinct registered model.",
+    )
+    character_array_run_all_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to persist the JSON CHARACTER ARRAY execution report.",
+    )
+    _add_health_decision_args(
+        character_array_run_all_parser,
+        "Run provider readiness checks before assigning and executing every CHARACTER ARRAY member role.",
     )
     return parser
 
@@ -1830,6 +1899,42 @@ def _character_array_member_result_to_dict(
         "execution": _execution_to_dict(result.execution),
         "roleAssignments": _character_profile_selection_to_dict(result.character_selection),
     }
+
+
+def _character_array_execution_result_to_dict(
+    result: CharacterArrayExecutionResult,
+) -> dict:
+    return {
+        "ok": result.ok,
+        "arrayId": result.array_id,
+        "primaryCharacterId": result.primary_character_id,
+        "memberCount": result.member_count,
+        "successfulCount": result.successful_count,
+        "failedCount": result.failed_count,
+        "members": [_character_array_member_result_to_dict(member) for member in result.member_results],
+    }
+
+
+def _parse_slot_role_overrides(raw: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for entry in raw:
+        if "=" not in entry:
+            raise SystemExit(
+                f"--role-id-for must be formatted as SLOT=ROLE (got {entry!r})"
+            )
+        slot, role = entry.split("=", 1)
+        slot = slot.strip()
+        role = role.strip()
+        if not slot or not role:
+            raise SystemExit(
+                f"--role-id-for must be formatted as SLOT=ROLE (got {entry!r})"
+            )
+        if slot in overrides:
+            raise SystemExit(
+                f"--role-id-for provided more than once for slot {slot!r}"
+            )
+        overrides[slot] = role
+    return overrides
 
 
 def _execution_to_dict(execution: ProviderExecutionResult) -> dict:

--- a/furyoku/runtime.py
+++ b/furyoku/runtime.py
@@ -140,6 +140,44 @@ class CharacterArrayMemberExecutionResult:
 
 
 @dataclass(frozen=True)
+class CharacterArrayExecutionResult:
+    """Executed role assignments for every CHARACTER member of an Agentic Character Array."""
+
+    array: CharacterArray
+    member_results: tuple[CharacterArrayMemberExecutionResult, ...]
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.member_results) and all(result.ok for result in self.member_results)
+
+    @property
+    def array_id(self) -> str:
+        return self.array.array_id
+
+    @property
+    def primary_character_id(self) -> str:
+        return self.array.primary_character_id
+
+    @property
+    def member_count(self) -> int:
+        return len(self.member_results)
+
+    @property
+    def successful_count(self) -> int:
+        return sum(1 for result in self.member_results if result.ok)
+
+    @property
+    def failed_count(self) -> int:
+        return self.member_count - self.successful_count
+
+    def member_result(self, slot_id: str) -> CharacterArrayMemberExecutionResult:
+        for result in self.member_results:
+            if result.slot_id == slot_id:
+                return result
+        raise CharacterArrayError(f"Unknown CHARACTER ARRAY slot '{slot_id}'")
+
+
+@dataclass(frozen=True)
 class DecisionSituationExecutionResult:
     """A calibrated decision-suite situation executed through a selected endpoint."""
 
@@ -642,6 +680,46 @@ def execute_character_array_member(
         slot_id=member.slot_id,
         role_result=role_result,
     )
+
+
+def execute_character_array(
+    models: list[ModelEndpoint],
+    array: CharacterArray,
+    request: ProviderExecutionRequest | str,
+    *,
+    role_id_by_slot: Mapping[str, str] | None = None,
+    default_role_id: str | None = None,
+    allow_reuse: bool = True,
+    readiness: ReadinessEvidenceInput | None = None,
+    adapters: Mapping[str, ProviderAdapter] | None = None,
+) -> CharacterArrayExecutionResult:
+    """Execute one role on every CHARACTER member of an Agentic Character Array."""
+
+    if not isinstance(array, CharacterArray):
+        raise CharacterArrayError(
+            "CHARACTER ARRAY execution requires a parsed CharacterArray"
+        )
+    overrides = dict(role_id_by_slot or {})
+    valid_slots = {member.slot_id for member in array.members}
+    unknown = sorted(slot for slot in overrides if slot not in valid_slots)
+    if unknown:
+        raise CharacterArrayError(
+            f"Unknown CHARACTER ARRAY slot(s) in role_id_by_slot: {', '.join(unknown)}"
+        )
+    member_results = tuple(
+        execute_character_array_member(
+            models,
+            array,
+            request,
+            slot_id=member.slot_id,
+            role_id=overrides.get(member.slot_id, default_role_id),
+            allow_reuse=allow_reuse,
+            readiness=readiness,
+            adapters=adapters,
+        )
+        for member in array.members
+    )
+    return CharacterArrayExecutionResult(array=array, member_results=member_results)
 
 
 def _execute_fallback_attempts(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2723,6 +2723,139 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["selectedModel"]["modelId"], "cli-coder")
             self.assertEqual(payload["execution"]["responseText"].strip(), "code:write code")
 
+    def test_character_array_run_all_fans_out_every_member(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            character_path = Path(temp_dir) / "character.json"
+            array_path = Path(temp_dir) / "array.json"
+            output_path = Path(temp_dir) / "reports" / "character-array-run-all.json"
+            write_executable_character_registry(registry_path)
+            write_character_profile(character_path)
+            array_payload = {
+                "schemaVersion": 1,
+                "arrayId": "cli-aca-fanout",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "profilePath": str(character_path),
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "cli-support-fanout",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "cli-support-fanout.primary",
+                                        "requiredCapabilities": {"conversation": 0.7},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+            array_path.write_text(json.dumps(array_payload), encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "character-array-run-all",
+                        "--registry",
+                        str(registry_path),
+                        "--character-array",
+                        str(array_path),
+                        "--prompt",
+                        "hello",
+                        "--output",
+                        str(output_path),
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            persisted = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["arrayId"], "cli-aca-fanout")
+            self.assertEqual(payload["memberCount"], 2)
+            self.assertEqual(payload["successfulCount"], 2)
+            self.assertEqual(payload["failedCount"], 0)
+            self.assertEqual(payload["members"][0]["slotId"], "lead")
+            self.assertTrue(payload["members"][0]["primary"])
+            self.assertEqual(payload["members"][0]["executedRoleId"], "primary")
+            self.assertEqual(payload["members"][0]["execution"]["responseText"].strip(), "echo:hello")
+            self.assertEqual(payload["members"][1]["slotId"], "support")
+            self.assertFalse(payload["members"][1]["primary"])
+            self.assertIn("generatedAt", persisted["reportMetadata"])
+
+    def test_character_array_run_all_applies_per_slot_role_override(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "models.json"
+            character_path = Path(temp_dir) / "character.json"
+            array_path = Path(temp_dir) / "array.json"
+            write_executable_character_registry(registry_path)
+            write_character_profile(character_path)
+            array_payload = {
+                "schemaVersion": 1,
+                "arrayId": "cli-aca-fanout-override",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "profilePath": str(character_path),
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "cli-support-fanout-override",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "cli-support-fanout-override.primary",
+                                        "requiredCapabilities": {"conversation": 0.7},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+            array_path.write_text(json.dumps(array_payload), encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "character-array-run-all",
+                        "--registry",
+                        str(registry_path),
+                        "--character-array",
+                        str(array_path),
+                        "--prompt",
+                        "hello",
+                        "--role-id-for",
+                        "lead=coding",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["memberCount"], 2)
+            self.assertEqual(payload["members"][0]["slotId"], "lead")
+            self.assertEqual(payload["members"][0]["executedRoleId"], "coding")
+            self.assertEqual(payload["members"][0]["execution"]["responseText"].strip(), "code:hello")
+            self.assertEqual(payload["members"][1]["slotId"], "support")
+            self.assertEqual(payload["members"][1]["executedRoleId"], "primary")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -15,6 +15,7 @@ from furyoku import (
     compare_decision_suite_executions,
     compare_decision_situation_executions,
     compare_model_executions,
+    execute_character_array,
     execute_character_array_member,
     execute_decision_situation,
     execute_decision_situation_with_fallback,
@@ -929,6 +930,199 @@ class RuntimeTests(unittest.TestCase):
             execute_character_array_member([local_endpoint()], array, "hello", slot_id="missing")
 
         self.assertIn("Unknown CHARACTER ARRAY slot", str(error.exception))
+
+    def test_execute_character_array_fans_out_each_members_primary_role(self):
+        array = parse_character_array(
+            {
+                "schemaVersion": 1,
+                "arrayId": "runtime-aca-fanout",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "lead-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "lead-character.primary",
+                                        "privacyRequirement": "local_only",
+                                        "requiredCapabilities": {"conversation": 0.9},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "support-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "support-character.primary",
+                                        "requireTools": True,
+                                        "requiredCapabilities": {"coding": 0.9},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+        )
+
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = execute_character_array(
+            [local_endpoint(), cli_endpoint()],
+            array,
+            "hello",
+            adapters={
+                "local": SubprocessProviderAdapter(runner),
+                "cli": SubprocessProviderAdapter(runner),
+            },
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.array_id, "runtime-aca-fanout")
+        self.assertEqual(result.member_count, 2)
+        self.assertEqual(result.successful_count, 2)
+        self.assertEqual(result.failed_count, 0)
+        lead = result.member_result("lead")
+        support = result.member_result("support")
+        self.assertEqual(lead.role_id, "primary")
+        self.assertEqual(lead.model_id, "local-chat")
+        self.assertEqual(lead.execution.response_text, "local-chat:hello")
+        self.assertEqual(support.role_id, "primary")
+        self.assertEqual(support.model_id, "cli-coder")
+        self.assertEqual(support.execution.response_text, "cli-coder:hello")
+
+    def test_execute_character_array_applies_per_slot_role_overrides(self):
+        array = parse_character_array(
+            {
+                "schemaVersion": 1,
+                "arrayId": "runtime-aca-overrides",
+                "members": [
+                    {
+                        "alias": "lead",
+                        "primary": True,
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "lead-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "lead-character.primary",
+                                        "privacyRequirement": "local_only",
+                                        "requiredCapabilities": {"conversation": 0.9},
+                                    },
+                                },
+                                {
+                                    "roleId": "coding",
+                                    "task": {
+                                        "taskId": "lead-character.coding",
+                                        "requireTools": True,
+                                        "requiredCapabilities": {"coding": 0.9},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "alias": "support",
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "support-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "support-character.primary",
+                                        "requiredCapabilities": {"conversation": 0.5},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+        )
+
+        def runner(invocation, prompt, timeout):
+            return subprocess.CompletedProcess(invocation, 0, stdout=f"{invocation[0]}:{prompt}", stderr="")
+
+        result = execute_character_array(
+            [local_endpoint(), cli_endpoint()],
+            array,
+            "hello",
+            role_id_by_slot={"lead": "coding"},
+            adapters={
+                "local": SubprocessProviderAdapter(runner),
+                "cli": SubprocessProviderAdapter(runner),
+            },
+        )
+
+        self.assertTrue(result.ok)
+        lead = result.member_result("lead")
+        support = result.member_result("support")
+        self.assertEqual(lead.role_id, "coding")
+        self.assertEqual(lead.model_id, "cli-coder")
+        self.assertEqual(lead.execution.response_text, "cli-coder:hello")
+        self.assertEqual(support.role_id, "primary")
+        self.assertTrue(support.ok)
+        self.assertEqual(
+            support.execution.response_text,
+            f"{support.model_id}:hello",
+        )
+
+    def test_execute_character_array_rejects_unknown_slot_override(self):
+        array = parse_character_array(
+            {
+                "schemaVersion": 1,
+                "arrayId": "runtime-aca-bad-override",
+                "members": [
+                    {
+                        "alias": "solo",
+                        "primary": True,
+                        "character": {
+                            "schemaVersion": 1,
+                            "characterId": "solo-character",
+                            "roles": [
+                                {
+                                    "roleId": "primary",
+                                    "primary": True,
+                                    "task": {
+                                        "taskId": "solo-character.primary",
+                                        "requiredCapabilities": {"conversation": 0.5},
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaises(CharacterArrayError) as error:
+            execute_character_array(
+                [local_endpoint()],
+                array,
+                "hello",
+                role_id_by_slot={"missing": "primary"},
+            )
+
+        self.assertIn("missing", str(error.exception))
 
     def test_execute_character_role_rejects_unknown_role(self):
         profile = parse_character_profile(


### PR DESCRIPTION
## Summary
- Adds `execute_character_array` runtime helper and `CharacterArrayExecutionResult` dataclass: executes every CHARACTER member of an Agentic Character Array in one invocation, defaulting to each member's primary role, with optional `default_role_id` or per-slot `role_id_by_slot` overrides. Rejects unknown slot overrides up front.
- Adds `character-array-run-all` CLI subcommand that loads the registry + ACA JSON, accepts a single `--prompt`, optional `--role-id` default, and repeatable `--role-id-for SLOT=ROLE` per-slot overrides. Writes a consolidated JSON report and exits `0` only if every member succeeded (otherwise `2`).
- Exposes both symbols through `furyoku/__init__.py`, documents the new surface in `README.md`, and bumps the active-lane banner from #282 to #284.

## Test plan
- [x] `python -m unittest tests.test_runtime tests.test_cli tests.test_character_arrays` (97 tests, all pass)
- [x] `python -m unittest discover -s tests` (320 tests, all pass, 707.4s)

Closes #284. Builds on #282 / [PR #283](https://github.com/JKhyro/FURYOKU/pull/283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)